### PR TITLE
Move items in root module to `mod json_rpc` to avoid name collisions

### DIFF
--- a/src/json_rpc.rs
+++ b/src/json_rpc.rs
@@ -1,0 +1,241 @@
+use serde::{Deserialize, Deserializer, Serialize};
+use serde_json::Value;
+
+use crate::{ErrorCodes, Notification, Request};
+
+fn deserialize_some<'de, T, D>(deserializer: D) -> Result<Option<T>, D::Error>
+where
+    T: Deserialize<'de>,
+    D: Deserializer<'de>,
+{
+    T::deserialize(deserializer).map(Some)
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+enum Version {
+    #[serde(rename = "2.0")]
+    TwoPointZero,
+}
+
+/// A unique ID used to correlate requests and responses together.
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum Id {
+    /// Numeric ID.
+    Number(i64),
+    /// String ID.
+    String(String),
+    /// Null ID.
+    ///
+    /// The use of Null as a value for the id member in a Request object is discouraged, because
+    /// this specification uses a value of Null for Responses with an unknown id. Also, because
+    /// JSON-RPC 1.0 uses an id value of Null for Notifications this could cause confusion in
+    /// handling.
+    Null,
+}
+
+/// A JSON-RPC Request (or Notification) object.
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize, Eq)]
+pub struct RequestObject {
+    /// A String specifying the version of the JSON-RPC protocol. MUST be exactly "2.0".
+    jsonrpc: Version,
+    /// An identifier established by the Client that MUST contain a String, Number, or NULL value if
+    /// included. If it is not included it is assumed to be a notification. The value SHOULD
+    /// normally not be Null and Numbers SHOULD NOT contain fractional parts.
+    #[serde(default, deserialize_with = "deserialize_some")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    id: Option<Id>,
+    /// A String containing the name of the method to be invoked. Method names that begin with the
+    /// word rpc followed by a period character (U+002E or ASCII 46) are reserved for rpc-internal
+    /// methods and extensions and MUST NOT be used for anything else.
+    #[serde(default)]
+    method: String,
+    /// A Structured value that holds the parameter values to be used during the invocation of the
+    /// method. This member MAY be omitted.
+    ///
+    /// If present, parameters for the rpc call MUST be provided as a Structured value. Either
+    /// by-position through an Array or by-name through an Object.
+    #[serde(default, deserialize_with = "deserialize_some")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    params: Option<Value>,
+}
+
+impl RequestObject {
+    /// Creates a JSON-RPC Request object from a server request.
+    ///
+    /// # Panics
+    ///
+    /// Will panic if `result` cannot be serialized (impossible unless the trait was implemented
+    /// incorrectly).
+    pub fn from_request<R>(id: Id, params: R::Params) -> Self
+    where
+        R: Request,
+    {
+        let params = serde_json::to_value(params).expect("Invalid request params");
+        let params = match params {
+            Value::Null => None,
+            Value::Array(_) | Value::Object(_) => Some(params),
+            _ => panic!("Parameters must be an object or array, if not omitted."),
+        };
+        Self {
+            jsonrpc: Version::TwoPointZero,
+            id: Some(id),
+            params,
+            method: R::METHOD.into(),
+        }
+    }
+
+    /// Creates a JSON-RPC Request object from a server notification.
+    ///
+    /// # Panics
+    ///
+    /// Will panic if `result` cannot be serialized (impossible unless the trait was implemented
+    /// incorrectly).
+    pub fn from_notification<N>(params: N::Params) -> Self
+    where
+        N: Notification,
+    {
+        let params = serde_json::to_value(params).expect("Invalid request params");
+        let params = match params {
+            Value::Null => None,
+            Value::Array(_) | Value::Object(_) => Some(params),
+            _ => panic!("Parameters must be an object or array, if not omitted."),
+        };
+        Self {
+            jsonrpc: Version::TwoPointZero,
+            method: N::METHOD.to_string(),
+            params,
+            id: None,
+        }
+    }
+
+    /// Returns the method to be invoked.
+    #[must_use]
+    pub fn method(&self) -> &str {
+        self.method.as_ref()
+    }
+
+    /// Returns the id.
+    #[must_use]
+    pub const fn id(&self) -> Option<&Id> {
+        self.id.as_ref()
+    }
+
+    /// Returns the params.
+    #[must_use]
+    pub const fn params(&self) -> Option<&Value> {
+        self.params.as_ref()
+    }
+
+    /// Splits the request into the method name, request ID, and the parameters.
+    #[must_use]
+    pub fn into_parts(self) -> (String, Option<Id>, Option<Value>) {
+        (self.method, self.id, self.params)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(untagged)]
+enum Kind {
+    /// This member is REQUIRED on success. This member MUST NOT exist if there was an error
+    /// invoking the method. The value of this member is determined by the method invoked on the
+    /// Server.
+    Ok { result: Value },
+    /// This member is REQUIRED on error. This member MUST NOT exist if there was no error triggered
+    /// during invocation. The value for this member MUST be an Object as defined in section 5.1.
+    Err { error: Error },
+}
+
+/// A JSON-RPC Error object.
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+pub struct Error {
+    /// A Number that indicates the error type that occurred.
+    pub code: ErrorCodes,
+    /// A String providing a short description of the error. The message SHOULD be limited to a
+    /// concise single sentence.
+    pub message: String,
+    /// A Primitive or Structured value that contains additional information about the error. This
+    /// may be omitted. The value of this member is defined by the Server (e.g. detailed error
+    /// information, nested errors etc.).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data: Option<Value>,
+}
+
+/// A JSON-RPC Response object.
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct ResponseObject {
+    /// A String specifying the version of the JSON-RPC protocol. MUST be exactly "2.0".
+    jsonrpc: Version,
+    #[serde(flatten)]
+    kind: Kind,
+    /// This member is REQUIRED. It MUST be the same as the value of the id member in the
+    /// Request Object. If there was an error in detecting the id in the Request object
+    /// (e.g. Parse error/Invalid Request), it MUST be Null.
+    id: Id,
+}
+
+impl ResponseObject {
+    /// Creates a successful Response object from a result value.
+    ///
+    /// # Panics
+    ///
+    /// Will panic if `result` cannot be serialized (impossible unless the trait was implemented
+    /// incorrectly).
+    pub fn from_success<R>(id: Id, result: R::Result) -> Self
+    where
+        R: Request,
+    {
+        let result = serde_json::to_value(result).unwrap();
+        Self {
+            jsonrpc: Version::TwoPointZero,
+            kind: Kind::Ok { result },
+            id,
+        }
+    }
+
+    /// Creates an error Response object from an error value.
+    #[must_use]
+    pub const fn from_error(id: Id, error: Error) -> Self {
+        Self {
+            jsonrpc: Version::TwoPointZero,
+            kind: Kind::Err { error },
+            id,
+        }
+    }
+
+    /// Returns `true` if the Response object indicates success.
+    #[must_use]
+    pub const fn is_ok(&self) -> bool {
+        matches!(self.kind, Kind::Ok { .. })
+    }
+
+    /// Returns `true` if the Response object indicates failure.
+    #[must_use]
+    pub const fn is_error(&self) -> bool {
+        !self.is_ok()
+    }
+
+    /// Returns the corresponding Response object ID.
+    #[must_use]
+    pub const fn id(&self) -> &Id {
+        &self.id
+    }
+
+    /// Returns the `result` value, if present.
+    #[must_use]
+    pub const fn result(&self) -> Option<&Value> {
+        match &self.kind {
+            Kind::Ok { result } => Some(result),
+            Kind::Err { .. } => None,
+        }
+    }
+
+    /// Returns the `error` object, if present.
+    #[must_use]
+    pub const fn error(&self) -> Option<&Error> {
+        match &self.kind {
+            Kind::Err { error } => Some(error),
+            Kind::Ok { .. } => None,
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,245 +1,7 @@
 mod generated;
+pub mod json_rpc;
 
 pub use generated::*;
-use serde::{Deserialize, Deserializer, Serialize};
-use serde_json::Value;
-
-fn deserialize_some<'de, T, D>(deserializer: D) -> Result<Option<T>, D::Error>
-where
-    T: Deserialize<'de>,
-    D: Deserializer<'de>,
-{
-    T::deserialize(deserializer).map(Some)
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
-enum Version {
-    #[serde(rename = "2.0")]
-    TwoPointZero,
-}
-
-/// A unique ID used to correlate requests and responses together.
-#[derive(Clone, Debug, Eq, Hash, PartialEq, Deserialize, Serialize)]
-#[serde(untagged)]
-pub enum Id {
-    /// Numeric ID.
-    Number(i64),
-    /// String ID.
-    String(String),
-    /// Null ID.
-    ///
-    /// The use of Null as a value for the id member in a Request object is discouraged, because
-    /// this specification uses a value of Null for Responses with an unknown id. Also, because
-    /// JSON-RPC 1.0 uses an id value of Null for Notifications this could cause confusion in
-    /// handling.
-    Null,
-}
-
-/// A JSON-RPC Request (or Notification) object.
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize, Eq)]
-pub struct RequestObject {
-    /// A String specifying the version of the JSON-RPC protocol. MUST be exactly "2.0".
-    jsonrpc: Version,
-    /// An identifier established by the Client that MUST contain a String, Number, or NULL value if
-    /// included. If it is not included it is assumed to be a notification. The value SHOULD
-    /// normally not be Null and Numbers SHOULD NOT contain fractional parts.
-    #[serde(default, deserialize_with = "deserialize_some")]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    id: Option<Id>,
-    /// A String containing the name of the method to be invoked. Method names that begin with the
-    /// word rpc followed by a period character (U+002E or ASCII 46) are reserved for rpc-internal
-    /// methods and extensions and MUST NOT be used for anything else.
-    #[serde(default)]
-    method: String,
-    /// A Structured value that holds the parameter values to be used during the invocation of the
-    /// method. This member MAY be omitted.
-    ///
-    /// If present, parameters for the rpc call MUST be provided as a Structured value. Either
-    /// by-position through an Array or by-name through an Object.
-    #[serde(default, deserialize_with = "deserialize_some")]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    params: Option<Value>,
-}
-
-impl RequestObject {
-    /// Creates a JSON-RPC Request object from a server request.
-    ///
-    /// # Panics
-    ///
-    /// Will panic if `result` cannot be serialized (impossible unless the trait was implemented
-    /// incorrectly).
-    pub fn from_request<R>(id: Id, params: R::Params) -> Self
-    where
-        R: Request,
-    {
-        let params = serde_json::to_value(params).expect("Invalid request params");
-        let params = match params {
-            Value::Null => None,
-            Value::Array(_) | Value::Object(_) => Some(params),
-            _ => panic!("Parameters must be an object or array, if not omitted."),
-        };
-        Self {
-            jsonrpc: Version::TwoPointZero,
-            id: Some(id),
-            params,
-            method: R::METHOD.into(),
-        }
-    }
-
-    /// Creates a JSON-RPC Request object from a server notification.
-    ///
-    /// # Panics
-    ///
-    /// Will panic if `result` cannot be serialized (impossible unless the trait was implemented
-    /// incorrectly).
-    pub fn from_notification<N>(params: N::Params) -> Self
-    where
-        N: Notification,
-    {
-        let params = serde_json::to_value(params).expect("Invalid request params");
-        let params = match params {
-            Value::Null => None,
-            Value::Array(_) | Value::Object(_) => Some(params),
-            _ => panic!("Parameters must be an object or array, if not omitted."),
-        };
-        Self {
-            jsonrpc: Version::TwoPointZero,
-            method: N::METHOD.to_string(),
-            params,
-            id: None,
-        }
-    }
-
-    /// Returns the method to be invoked.
-    #[must_use]
-    pub fn method(&self) -> &str {
-        self.method.as_ref()
-    }
-
-    /// Returns the id.
-    #[must_use]
-    pub const fn id(&self) -> Option<&Id> {
-        self.id.as_ref()
-    }
-
-    /// Returns the params.
-    #[must_use]
-    pub const fn params(&self) -> Option<&Value> {
-        self.params.as_ref()
-    }
-
-    /// Splits the request into the method name, request ID, and the parameters.
-    #[must_use]
-    pub fn into_parts(self) -> (String, Option<Id>, Option<Value>) {
-        (self.method, self.id, self.params)
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
-#[serde(untagged)]
-enum Kind {
-    /// This member is REQUIRED on success. This member MUST NOT exist if there was an error
-    /// invoking the method. The value of this member is determined by the method invoked on the
-    /// Server.
-    Ok { result: Value },
-    /// This member is REQUIRED on error. This member MUST NOT exist if there was no error triggered
-    /// during invocation. The value for this member MUST be an Object as defined in section 5.1.
-    Err { error: Error },
-}
-
-/// A JSON-RPC Error object.
-#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
-pub struct Error {
-    /// A Number that indicates the error type that occurred.
-    pub code: ErrorCodes,
-    /// A String providing a short description of the error. The message SHOULD be limited to a
-    /// concise single sentence.
-    pub message: String,
-    /// A Primitive or Structured value that contains additional information about the error. This
-    /// may be omitted. The value of this member is defined by the Server (e.g. detailed error
-    /// information, nested errors etc.).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub data: Option<Value>,
-}
-
-/// A JSON-RPC Response object.
-#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
-pub struct ResponseObject {
-    /// A String specifying the version of the JSON-RPC protocol. MUST be exactly "2.0".
-    jsonrpc: Version,
-    #[serde(flatten)]
-    kind: Kind,
-    /// This member is REQUIRED. It MUST be the same as the value of the id member in the
-    /// Request Object. If there was an error in detecting the id in the Request object
-    /// (e.g. Parse error/Invalid Request), it MUST be Null.
-    id: Id,
-}
-
-impl ResponseObject {
-    /// Creates a successful Response object from a result value.
-    ///
-    /// # Panics
-    ///
-    /// Will panic if `result` cannot be serialized (impossible unless the trait was implemented
-    /// incorrectly).
-    pub fn from_success<R>(id: Id, result: R::Result) -> Self
-    where
-        R: Request,
-    {
-        let result = serde_json::to_value(result).unwrap();
-        Self {
-            jsonrpc: Version::TwoPointZero,
-            kind: Kind::Ok { result },
-            id,
-        }
-    }
-
-    /// Creates an error Response object from an error value.
-    #[must_use]
-    pub const fn from_error(id: Id, error: Error) -> Self {
-        Self {
-            jsonrpc: Version::TwoPointZero,
-            kind: Kind::Err { error },
-            id,
-        }
-    }
-
-    /// Returns `true` if the Response object indicates success.
-    #[must_use]
-    pub const fn is_ok(&self) -> bool {
-        matches!(self.kind, Kind::Ok { .. })
-    }
-
-    /// Returns `true` if the Response object indicates failure.
-    #[must_use]
-    pub const fn is_error(&self) -> bool {
-        !self.is_ok()
-    }
-
-    /// Returns the corresponding Response object ID.
-    #[must_use]
-    pub const fn id(&self) -> &Id {
-        &self.id
-    }
-
-    /// Returns the `result` value, if present.
-    #[must_use]
-    pub const fn result(&self) -> Option<&Value> {
-        match &self.kind {
-            Kind::Ok { result } => Some(result),
-            Kind::Err { .. } => None,
-        }
-    }
-
-    /// Returns the `error` object, if present.
-    #[must_use]
-    pub const fn error(&self) -> Option<&Error> {
-        match &self.kind {
-            Kind::Err { error } => Some(error),
-            Kind::Ok { .. } => None,
-        }
-    }
-}
 
 #[cfg(test)]
 mod test {
@@ -591,8 +353,10 @@ mod test {
                 position: Position::default(),
             },
         };
-        let req =
-            RequestObject::from_request::<TypeDefinitionRequest>(Id::Number(123), params.clone());
+        let req = json_rpc::RequestObject::from_request::<TypeDefinitionRequest>(
+            json_rpc::Id::Number(123),
+            params.clone(),
+        );
 
         let ser = serde_json::to_string(&req).unwrap();
 
@@ -600,15 +364,17 @@ mod test {
             ser,
             r#"{"jsonrpc":"2.0","id":123,"method":"textDocument/typeDefinition","params":{"position":{"character":0,"line":0},"textDocument":{"uri":"foo"}}}"#
         );
-        assert_eq!(req.id(), Some(&Id::Number(123)));
+        assert_eq!(req.id(), Some(&json_rpc::Id::Number(123)));
         assert_eq!(req.method(), "textDocument/typeDefinition");
         assert_eq!(req.params(), Some(&serde_json::to_value(params).unwrap()));
     }
 
     #[test]
     fn request_object_from_request_no_params() {
-        let req =
-            RequestObject::from_request::<WorkspaceFoldersRequest>(Id::String("foo".into()), ());
+        let req = json_rpc::RequestObject::from_request::<WorkspaceFoldersRequest>(
+            json_rpc::Id::String("foo".into()),
+            (),
+        );
 
         let ser = serde_json::to_string(&req).unwrap();
 
@@ -620,8 +386,9 @@ mod test {
 
     #[test]
     fn request_object_from_notification() {
-        let noti =
-            RequestObject::from_notification::<InitializedNotification>(InitializedParams {});
+        let noti = json_rpc::RequestObject::from_notification::<InitializedNotification>(
+            InitializedParams {},
+        );
 
         let ser = serde_json::to_string(&noti).unwrap();
 
@@ -639,7 +406,7 @@ mod test {
 
     #[test]
     fn request_object_from_notification_no_params() {
-        let noti = RequestObject::from_notification::<ExitNotification>(());
+        let noti = json_rpc::RequestObject::from_notification::<ExitNotification>(());
 
         let ser = serde_json::to_string(&noti).unwrap();
 
@@ -648,9 +415,9 @@ mod test {
 
     #[test]
     fn response_object_from_success() {
-        let id = Id::Number(123);
+        let id = json_rpc::Id::Number(123);
 
-        let res = ResponseObject::from_success::<ImplementationRequest>(
+        let res = json_rpc::ResponseObject::from_success::<ImplementationRequest>(
             id.clone(),
             Some(ImplementationRequestResponse::DefinitionLinkList(Vec::new())),
         );
@@ -659,25 +426,25 @@ mod test {
         assert_eq!(r#"{"jsonrpc":"2.0","result":[],"id":123}"#, &ser);
         assert_eq!(res, serde_json::from_str(&ser).unwrap());
 
-        let res = ResponseObject::from_success::<ImplementationRequest>(id.clone(), None);
+        let res = json_rpc::ResponseObject::from_success::<ImplementationRequest>(id.clone(), None);
 
         let ser = serde_json::to_string(&res).unwrap();
         assert_eq!(r#"{"jsonrpc":"2.0","result":null,"id":123}"#, &ser);
         assert_eq!(res, serde_json::from_str(&ser).unwrap());
 
-        let res = ResponseObject::from_success::<ImplementationRequest>(id.clone(), None);
+        let res = json_rpc::ResponseObject::from_success::<ImplementationRequest>(id.clone(), None);
 
         let ser = serde_json::to_string(&res).unwrap();
         assert_eq!(r#"{"jsonrpc":"2.0","result":null,"id":123}"#, &ser);
         assert_eq!(res, serde_json::from_str(&ser).unwrap());
 
-        let res = ResponseObject::from_success::<ShowMessageRequest>(id.clone(), None);
+        let res = json_rpc::ResponseObject::from_success::<ShowMessageRequest>(id.clone(), None);
 
         let ser = serde_json::to_string(&res).unwrap();
         assert_eq!(r#"{"jsonrpc":"2.0","result":null,"id":123}"#, &ser);
         assert_eq!(res, serde_json::from_str(&ser).unwrap());
 
-        let res = ResponseObject::from_success::<ShowMessageRequest>(
+        let res = json_rpc::ResponseObject::from_success::<ShowMessageRequest>(
             id.clone(),
             Some(crate::MessageActionItem {
                 title: "foo".into(),
@@ -691,7 +458,7 @@ mod test {
         );
         assert_eq!(res, serde_json::from_str(&ser).unwrap());
 
-        let res = ResponseObject::from_success::<CodeLensRefreshRequest>(id, ());
+        let res = json_rpc::ResponseObject::from_success::<CodeLensRefreshRequest>(id, ());
 
         let ser = serde_json::to_string(&res).unwrap();
         assert_eq!(r#"{"jsonrpc":"2.0","result":null,"id":123}"#, &ser);
@@ -700,10 +467,10 @@ mod test {
 
     #[test]
     fn response_object_from_error() {
-        let id = Id::Null;
-        let res = ResponseObject::from_error(
+        let id = json_rpc::Id::Null;
+        let res = json_rpc::ResponseObject::from_error(
             id,
-            Error {
+            json_rpc::Error {
                 code: crate::ErrorCodes::ParseError,
                 message: "invalid format".into(),
                 data: None,
@@ -716,10 +483,10 @@ mod test {
             &ser
         );
 
-        let id = Id::String("foo-req".into());
-        let res = ResponseObject::from_error(
+        let id = json_rpc::Id::String("foo-req".into());
+        let res = json_rpc::ResponseObject::from_error(
             id,
-            Error {
+            json_rpc::Error {
                 code: crate::ErrorCodes::Custom(-32803),
                 message: "failed to foo the bar".into(),
                 data: Some(serde_json::to_value(String::from("hi")).unwrap()),
@@ -732,10 +499,10 @@ mod test {
             &ser
         );
 
-        let id = Id::String("foo-req".into());
-        let res = ResponseObject::from_error(
+        let id = json_rpc::Id::String("foo-req".into());
+        let res = json_rpc::ResponseObject::from_error(
             id,
-            Error {
+            json_rpc::Error {
                 code: crate::ErrorCodes::Custom(crate::LspErrorCodes::ContentModified.into()),
                 message: "failed to foo the bar".into(),
                 data: Some(serde_json::to_value(String::from("hi")).unwrap()),
@@ -810,7 +577,8 @@ mod test {
             const MESSAGE_DIRECTION: MessageDirection = MessageDirection::ClientToServer;
         }
 
-        let req = RequestObject::from_request::<ParentModule>(Id::Number(123), ());
+        let req =
+            json_rpc::RequestObject::from_request::<ParentModule>(json_rpc::Id::Number(123), ());
         assert_eq!(
             r#"{"jsonrpc":"2.0","id":123,"method":"experimental/parentModule"}"#,
             serde_json::to_string(&req).unwrap()
@@ -824,7 +592,7 @@ mod test {
             const MESSAGE_DIRECTION: MessageDirection = MessageDirection::ClientToServer;
         }
 
-        let noti = RequestObject::from_notification::<ServerStatusNotification>(());
+        let noti = json_rpc::RequestObject::from_notification::<ServerStatusNotification>(());
         assert_eq!(
             r#"{"jsonrpc":"2.0","method":"experimental/serverStatus"}"#,
             serde_json::to_string(&noti).unwrap()


### PR DESCRIPTION
- Rename Id to `json_rpc::Id` to fix name collision.
  - Fixes #10 
- Move all other JSON RPC-related items into a public module.