### PR TITLE
feat: handle semantic tokens specially

### DIFF
--- a/src/generated.rs
+++ b/src/generated.rs
@@ -11,7 +11,9 @@
 
 use derive_more::From;
 use derive_new::new as New;
-use serde::{de::DeserializeOwned, Deserialize, Deserializer, Serialize};
+use serde::{
+    de::DeserializeOwned, Deserialize, Deserializer, ser::SerializeSeq as _, Serialize,
+};
 use std::{borrow::Cow, collections::HashMap, fmt};
 
 fn deserialize_some<'de, T, D>(deserializer: D) -> Result<Option<T>, D::Error>
@@ -51,6 +53,94 @@ impl AsRef<str> for Uri {
 impl fmt::Display for Uri {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.0)
+    }
+}
+/// Represents a semantic token (serialized as five uintegers).
+#[derive(Debug, Eq, PartialEq, Copy, Clone, Default, Hash)]
+pub struct SemanticToken {
+    /// Token line number, relative to the start of the previous token.
+    pub delta_line: u32,
+    /// Token start character, relative to the start of the previous token (relative to 0 or
+    /// the previous token’s start if they are on the same line).
+    pub delta_start: u32,
+    /// The length of the token.
+    pub length: u32,
+    /// Will be looked up in [`SemanticTokensLegend::token_types`]. We currently ask that
+    /// `tokenType` < 65536.
+    pub token_type: u32,
+    /// Each set bit will be looked up in [`SemanticTokensLegend::token_modifiers`].
+    pub token_modifiers_bitset: u32,
+}
+impl SemanticToken {
+    fn deserialize_tokens<'de, D>(
+        deserializer: D,
+    ) -> Result<Vec<SemanticToken>, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let data = Vec::<u32>::deserialize(deserializer)?;
+        let chunks = data.chunks_exact(5);
+        if !chunks.remainder().is_empty() {
+            return Result::Err(serde::de::Error::custom("Length is not divisible by 5"));
+        }
+        Result::Ok(
+            chunks
+                .map(|chunk| SemanticToken {
+                    delta_line: chunk[0],
+                    delta_start: chunk[1],
+                    length: chunk[2],
+                    token_type: chunk[3],
+                    token_modifiers_bitset: chunk[4],
+                })
+                .collect(),
+        )
+    }
+    fn serialize_tokens<S>(
+        tokens: &[SemanticToken],
+        serializer: S,
+    ) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut seq = serializer.serialize_seq(Some(tokens.len() * 5))?;
+        for token in tokens.iter() {
+            seq.serialize_element(&token.delta_line)?;
+            seq.serialize_element(&token.delta_start)?;
+            seq.serialize_element(&token.length)?;
+            seq.serialize_element(&token.token_type)?;
+            seq.serialize_element(&token.token_modifiers_bitset)?;
+        }
+        seq.end()
+    }
+    fn deserialize_optional_tokens<'de, D>(
+        deserializer: D,
+    ) -> Result<Option<Vec<SemanticToken>>, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(transparent)]
+        struct Wrapper {
+            #[serde(deserialize_with = "SemanticToken::deserialize_tokens")]
+            tokens: Vec<SemanticToken>,
+        }
+        Ok(Option::<Wrapper>::deserialize(deserializer)?.map(|wrapper| wrapper.tokens))
+    }
+    fn serialize_optional_tokens<S>(
+        data: &Option<Vec<SemanticToken>>,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        #[derive(Serialize)]
+        #[serde(transparent)]
+        struct Wrapper {
+            #[serde(serialize_with = "SemanticToken::serialize_tokens")]
+            tokens: Vec<SemanticToken>,
+        }
+        let opt = data.as_ref().map(|t| Wrapper { tokens: t.to_vec() });
+        opt.serialize(serializer)
     }
 }
 
@@ -475,14 +565,22 @@ pub struct SemanticTokens {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub result_id: Option<String>,
     /// The actual tokens.
-    pub data: Vec<u32>,
+    #[serde(
+        deserialize_with = "SemanticToken::deserialize_tokens",
+        serialize_with = "SemanticToken::serialize_tokens"
+    )]
+    pub data: Vec<SemanticToken>,
 }
 
 /// @since 3.16.0
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone, New, Eq, Hash, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct SemanticTokensPartialResult {
-    pub data: Vec<u32>,
+    #[serde(
+        deserialize_with = "SemanticToken::deserialize_tokens",
+        serialize_with = "SemanticToken::serialize_tokens"
+    )]
+    pub data: Vec<SemanticToken>,
 }
 
 /// @since 3.16.0
@@ -2897,8 +2995,13 @@ pub struct SemanticTokensEdit {
     /// The count of elements to remove.
     pub delete_count: u32,
     /// The elements to insert.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub data: Option<Vec<u32>>,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "SemanticToken::deserialize_optional_tokens",
+        serialize_with = "SemanticToken::serialize_optional_tokens"
+    )]
+    pub data: Option<Vec<SemanticToken>>,
 }
 
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone, New, Eq, Hash, Default, Copy)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -799,24 +799,150 @@ mod test {
         );
     }
 
-    // Compile test to ensure constness of certain enums
+    #[test]
+    fn custom_request_object_methods() {
+        struct ParentModule;
+        impl Request for ParentModule {
+            type Params = ();
+            type Result = Option<DefinitionRequestResponse>;
+            const METHOD: LspRequestMethods =
+                LspRequestMethods::Custom(Cow::Borrowed("experimental/parentModule"));
+            const MESSAGE_DIRECTION: MessageDirection = MessageDirection::ClientToServer;
+        }
 
-    enum _ParentModule {}
+        let req = RequestObject::from_request::<ParentModule>(Id::Number(123), ());
+        assert_eq!(
+            r#"{"jsonrpc":"2.0","id":123,"method":"experimental/parentModule"}"#,
+            serde_json::to_string(&req).unwrap()
+        );
 
-    impl Request for _ParentModule {
-        type Params = ();
-        type Result = Option<DefinitionRequestResponse>;
-        const METHOD: LspRequestMethods =
-            LspRequestMethods::Custom(Cow::Borrowed("experimental/parentModule"));
-        const MESSAGE_DIRECTION: MessageDirection = MessageDirection::ClientToServer;
+        struct ServerStatusNotification;
+        impl Notification for ServerStatusNotification {
+            type Params = ();
+            const METHOD: LspNotificationMethods =
+                LspNotificationMethods::Custom(Cow::Borrowed("experimental/serverStatus"));
+            const MESSAGE_DIRECTION: MessageDirection = MessageDirection::ClientToServer;
+        }
+
+        let noti = RequestObject::from_notification::<ServerStatusNotification>(());
+        assert_eq!(
+            r#"{"jsonrpc":"2.0","method":"experimental/serverStatus"}"#,
+            serde_json::to_string(&noti).unwrap()
+        );
     }
 
-    enum _ServerStatusNotification {}
+    #[test]
+    fn semantic_tokens() {
+        let ste = SemanticTokensEdit {
+            start: 0,
+            delete_count: 1,
+            data: None,
+        };
+        let ste_ser = r#"{"start":0,"deleteCount":1}"#;
+        assert_eq!(serde_json::to_string(&ste).unwrap(), ste_ser);
+        assert_eq!(ste, serde_json::from_str(ste_ser).unwrap());
 
-    impl Notification for _ServerStatusNotification {
-        type Params = ();
-        const METHOD: LspNotificationMethods =
-            LspNotificationMethods::Custom(Cow::Borrowed("experimental/serverStatus"));
-        const MESSAGE_DIRECTION: MessageDirection = MessageDirection::ClientToServer;
+        let ste = SemanticTokensEdit {
+            start: 0,
+            delete_count: 1,
+            data: None,
+        };
+        let ste_ser_fake = r#"{"start":0,"deleteCount":1,"data":null}"#;
+        assert_eq!(serde_json::to_string(&ste).unwrap(), ste_ser);
+        // Be permissive on technically incorrect deserialization.
+        assert_eq!(ste, serde_json::from_str(ste_ser_fake).unwrap());
+
+        let ste = SemanticTokensEdit {
+            start: 0,
+            delete_count: 1,
+            data: Some(vec![
+                SemanticToken {
+                    delta_line: 2,
+                    delta_start: 5,
+                    length: 3,
+                    token_type: 0,
+                    token_modifiers_bitset: 3,
+                },
+                SemanticToken {
+                    delta_line: 0,
+                    delta_start: 5,
+                    length: 4,
+                    token_type: 1,
+                    token_modifiers_bitset: 0,
+                },
+            ]),
+        };
+        let ste_ser = r#"{"start":0,"deleteCount":1,"data":[2,5,3,0,3,0,5,4,1,0]}"#;
+        assert_eq!(serde_json::to_string(&ste).unwrap(), ste_ser);
+        assert_eq!(ste, serde_json::from_str(ste_ser).unwrap());
+
+        let ste = SemanticTokensEdit {
+            start: 0,
+            delete_count: 1,
+            data: Some(Vec::new()),
+        };
+        let ste_ser = r#"{"start":0,"deleteCount":1,"data":[]}"#;
+        assert_eq!(serde_json::to_string(&ste).unwrap(), ste_ser);
+        assert_eq!(ste, serde_json::from_str(ste_ser).unwrap());
+
+        let st = SemanticTokens {
+            result_id: None,
+            data: Vec::default(),
+        };
+        let st_ser = r#"{"data":[]}"#;
+        assert_eq!(serde_json::to_string(&st).unwrap(), st_ser);
+        assert_eq!(st, serde_json::from_str(st_ser).unwrap());
+
+        let st = SemanticTokens {
+            result_id: None,
+            data: vec![
+                SemanticToken {
+                    delta_line: 2,
+                    delta_start: 5,
+                    length: 3,
+                    token_type: 0,
+                    token_modifiers_bitset: 3,
+                },
+                SemanticToken {
+                    delta_line: 0,
+                    delta_start: 5,
+                    length: 4,
+                    token_type: 1,
+                    token_modifiers_bitset: 0,
+                },
+            ],
+        };
+        let st_ser = r#"{"data":[2,5,3,0,3,0,5,4,1,0]}"#;
+        assert_eq!(serde_json::to_string(&st).unwrap(), st_ser);
+        assert_eq!(st, serde_json::from_str(st_ser).unwrap());
+
+        let stpr = SemanticTokensPartialResult {
+            data: vec![
+                SemanticToken {
+                    delta_line: 2,
+                    delta_start: 5,
+                    length: 3,
+                    token_type: 0,
+                    token_modifiers_bitset: 3,
+                },
+                SemanticToken {
+                    delta_line: 0,
+                    delta_start: 5,
+                    length: 4,
+                    token_type: 1,
+                    token_modifiers_bitset: 0,
+                },
+            ],
+        };
+        let stpr_ser = r#"{"data":[2,5,3,0,3,0,5,4,1,0]}"#;
+        assert_eq!(serde_json::to_string(&stpr).unwrap(), stpr_ser);
+        assert_eq!(stpr, serde_json::from_str(stpr_ser).unwrap());
+
+        let stpr = SemanticTokensPartialResult {
+            data: Vec::default(),
+        };
+        let stpr_ser = r#"{"data":[]}"#;
+        assert_eq!(serde_json::to_string(&stpr).unwrap(), stpr_ser);
+        assert_eq!(stpr, serde_json::from_str(stpr_ser).unwrap());
     }
 }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -22,11 +22,7 @@ use crate::{
     },
 };
 
-// TODO: Add CI to ensure the locally copied metaModel matches the one at this URL.
-// const METAMODEL_URL: &str = "https://raw.githubusercontent.com/microsoft/language-server-protocol/gh-pages/_specifications/lsp/3.18/metaModel/metaModel.json";
-
 mod schema {
-    // TODO: Add CI check to ensure that the locally copied schema still matches the GitHub source.
     typify::import_types!("metaModel.schema.json");
 }
 
@@ -476,7 +472,7 @@ fn main() {
     let imports = quote! {
         use derive_more::From;
         use derive_new::new as New;
-        use serde::{de::DeserializeOwned, Deserialize, Deserializer, Serialize};
+        use serde::{de::DeserializeOwned, Deserialize, Deserializer, ser::SerializeSeq as _, Serialize};
         use std::{borrow::Cow, collections::HashMap, fmt};
     };
 
@@ -524,6 +520,99 @@ fn main() {
         impl fmt::Display for Uri {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 write!(f, "{}", self.0)
+            }
+        }
+
+        /// Represents a semantic token (serialized as five uintegers).
+        #[derive(Debug, Eq, PartialEq, Copy, Clone, Default, Hash)]
+        pub struct SemanticToken {
+            /// Token line number, relative to the start of the previous token.
+            pub delta_line: u32,
+            /// Token start character, relative to the start of the previous token (relative to 0 or
+            /// the previous token’s start if they are on the same line).
+            pub delta_start: u32,
+            /// The length of the token.
+            pub length: u32,
+            /// Will be looked up in [`SemanticTokensLegend::token_types`]. We currently ask that
+            /// `tokenType` < 65536.
+            pub token_type: u32,
+            /// Each set bit will be looked up in [`SemanticTokensLegend::token_modifiers`].
+            pub token_modifiers_bitset: u32,
+        }
+
+        impl SemanticToken {
+            fn deserialize_tokens<'de, D>(deserializer: D) -> Result<Vec<SemanticToken>, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                let data = Vec::<u32>::deserialize(deserializer)?;
+                let chunks = data.chunks_exact(5);
+
+                if !chunks.remainder().is_empty() {
+                    return Result::Err(serde::de::Error::custom("Length is not divisible by 5"));
+                }
+
+                Result::Ok(
+                    chunks
+                        .map(|chunk| SemanticToken {
+                            delta_line: chunk[0],
+                            delta_start: chunk[1],
+                            length: chunk[2],
+                            token_type: chunk[3],
+                            token_modifiers_bitset: chunk[4],
+                        })
+                        .collect(),
+                )
+            }
+
+            fn serialize_tokens<S>(tokens: &[SemanticToken], serializer: S) -> Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                let mut seq = serializer.serialize_seq(Some(tokens.len() * 5))?;
+                for token in tokens.iter() {
+                    seq.serialize_element(&token.delta_line)?;
+                    seq.serialize_element(&token.delta_start)?;
+                    seq.serialize_element(&token.length)?;
+                    seq.serialize_element(&token.token_type)?;
+                    seq.serialize_element(&token.token_modifiers_bitset)?;
+                }
+                seq.end()
+            }
+
+            fn deserialize_optional_tokens<'de, D>(
+                deserializer: D,
+            ) -> Result<Option<Vec<SemanticToken>>, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                #[derive(Deserialize)]
+                #[serde(transparent)]
+                struct Wrapper {
+                    #[serde(deserialize_with = "SemanticToken::deserialize_tokens")]
+                    tokens: Vec<SemanticToken>,
+                }
+
+                Ok(Option::<Wrapper>::deserialize(deserializer)?.map(|wrapper| wrapper.tokens))
+            }
+
+            fn serialize_optional_tokens<S>(
+                data: &Option<Vec<SemanticToken>>,
+                serializer: S,
+            ) -> Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                #[derive(Serialize)]
+                #[serde(transparent)]
+                struct Wrapper {
+                    #[serde(serialize_with = "SemanticToken::serialize_tokens")]
+                    tokens: Vec<SemanticToken>,
+                }
+
+                let opt = data.as_ref().map(|t| Wrapper { tokens: t.to_vec() });
+
+                opt.serialize(serializer)
             }
         }
     };

--- a/xtask/src/renderers.rs
+++ b/xtask/src/renderers.rs
@@ -9,7 +9,7 @@ use crate::{
     is_nullable, method_to_pascal, render_documentation, resolve_struct_properties,
     schema::{
         BaseType, BaseTypes, Enumeration, EnumerationEntryValue, EnumerationTypeName, MapKeyType,
-        MapKeyTypeObjectName, Notification, OrType, Request, Structure, Type, TypeAlias,
+        MapKeyTypeObjectName, Notification, OrType, Property, Request, Structure, Type, TypeAlias,
     },
 };
 
@@ -485,6 +485,51 @@ pub fn render_enumeration(enumeration: Enumeration) -> TokenStream {
     }
 }
 
+/// Some properties should be handled specially, since further typing conveniences can be created
+/// beyond what the Metamodel provides.
+fn get_special_property(structure_name: &str, property: &Property) -> Option<TokenStream> {
+    let property_name = property.name.as_str();
+    match (structure_name, property_name) {
+        ("SemanticTokensEdit", "data") => {
+            assert_eq!(property.optional, Some(true));
+            let documentation = render_documentation(property.documentation.clone());
+            let deprecated = property
+                .deprecated
+                .as_ref()
+                .map(|note| quote! { #[deprecated(note = #note)] });
+            Some(quote! {
+                #documentation
+                #deprecated
+                #[serde(
+                    default,
+                    skip_serializing_if = "Option::is_none",
+                    deserialize_with = "SemanticToken::deserialize_optional_tokens",
+                    serialize_with = "SemanticToken::serialize_optional_tokens"
+                )]
+                pub data: Option<Vec<SemanticToken>>,
+            })
+        }
+        ("SemanticTokens", "data") | ("SemanticTokensPartialResult", "data") => {
+            assert_ne!(property.optional, Some(true));
+            let documentation = render_documentation(property.documentation.clone());
+            let deprecated = property
+                .deprecated
+                .as_ref()
+                .map(|note| quote! { #[deprecated(note = #note)] });
+            Some(quote! {
+                #documentation
+                #deprecated
+                #[serde(
+                    deserialize_with = "SemanticToken::deserialize_tokens",
+                    serialize_with = "SemanticToken::serialize_tokens"
+                )]
+                pub data: Vec<SemanticToken>,
+            })
+        }
+        _ => None,
+    }
+}
+
 pub fn render_structure(
     structure: Structure,
     structs_map: &HashMap<String, Structure>,
@@ -528,6 +573,10 @@ pub fn render_structure(
         .clone()
         .into_iter()
         .flat_map(|property| {
+            if let Some(special_prop) = get_special_property(&structure.name, &property) {
+                return Some(special_prop);
+            }
+
             if matches!(property.type_, Type::StringLiteralType(_)) {
                 string_lit_prop = Some(property);
                 return None;


### PR DESCRIPTION
Similar to lsp-types, this crate will now provide a specialized type around the semantic token concept. Instead of passing raw `u32` vectors, downstream will now pass in vectors of `SemanticToken`, a new helper struct, which has a custom (de)serializer to properly convert to/from raw `uinteger` arrays.