### PR TITLE
feat: add `lsp_request!` and `lsp_notification!` macros

### DIFF
--- a/src/generated.rs
+++ b/src/generated.rs
@@ -16625,3 +16625,312 @@ impl Notification for ProgressNotification {
     const MESSAGE_DIRECTION: MessageDirection = MessageDirection::Both;
     type Params = ProgressParams;
 }
+
+/// Get the [`Request`] type for a request method.
+///
+/// Example:
+///
+/// ```
+/// use gen_lsp_types::{Request, lsp_request};
+/// let params: <lsp_request!("textDocument/formatting") as Request>::Params;
+/// ```
+#[macro_export]
+macro_rules! lsp_request {
+    ("textDocument/implementation") => {
+        $crate::ImplementationRequest
+    };
+    ("textDocument/typeDefinition") => {
+        $crate::TypeDefinitionRequest
+    };
+    ("workspace/workspaceFolders") => {
+        $crate::WorkspaceFoldersRequest
+    };
+    ("workspace/configuration") => {
+        $crate::ConfigurationRequest
+    };
+    ("textDocument/documentColor") => {
+        $crate::DocumentColorRequest
+    };
+    ("textDocument/colorPresentation") => {
+        $crate::ColorPresentationRequest
+    };
+    ("textDocument/foldingRange") => {
+        $crate::FoldingRangeRequest
+    };
+    ("workspace/foldingRange/refresh") => {
+        $crate::FoldingRangeRefreshRequest
+    };
+    ("textDocument/declaration") => {
+        $crate::DeclarationRequest
+    };
+    ("textDocument/selectionRange") => {
+        $crate::SelectionRangeRequest
+    };
+    ("window/workDoneProgress/create") => {
+        $crate::WorkDoneProgressCreateRequest
+    };
+    ("textDocument/prepareCallHierarchy") => {
+        $crate::CallHierarchyPrepareRequest
+    };
+    ("callHierarchy/incomingCalls") => {
+        $crate::CallHierarchyIncomingCallsRequest
+    };
+    ("callHierarchy/outgoingCalls") => {
+        $crate::CallHierarchyOutgoingCallsRequest
+    };
+    ("textDocument/semanticTokens/full") => {
+        $crate::SemanticTokensRequest
+    };
+    ("textDocument/semanticTokens/full/delta") => {
+        $crate::SemanticTokensDeltaRequest
+    };
+    ("textDocument/semanticTokens/range") => {
+        $crate::SemanticTokensRangeRequest
+    };
+    ("workspace/semanticTokens/refresh") => {
+        $crate::SemanticTokensRefreshRequest
+    };
+    ("window/showDocument") => {
+        $crate::ShowDocumentRequest
+    };
+    ("textDocument/linkedEditingRange") => {
+        $crate::LinkedEditingRangeRequest
+    };
+    ("workspace/willCreateFiles") => {
+        $crate::WillCreateFilesRequest
+    };
+    ("workspace/willRenameFiles") => {
+        $crate::WillRenameFilesRequest
+    };
+    ("workspace/willDeleteFiles") => {
+        $crate::WillDeleteFilesRequest
+    };
+    ("textDocument/moniker") => {
+        $crate::MonikerRequest
+    };
+    ("textDocument/prepareTypeHierarchy") => {
+        $crate::TypeHierarchyPrepareRequest
+    };
+    ("typeHierarchy/supertypes") => {
+        $crate::TypeHierarchySupertypesRequest
+    };
+    ("typeHierarchy/subtypes") => {
+        $crate::TypeHierarchySubtypesRequest
+    };
+    ("textDocument/inlineValue") => {
+        $crate::InlineValueRequest
+    };
+    ("workspace/inlineValue/refresh") => {
+        $crate::InlineValueRefreshRequest
+    };
+    ("textDocument/inlayHint") => {
+        $crate::InlayHintRequest
+    };
+    ("inlayHint/resolve") => {
+        $crate::InlayHintResolveRequest
+    };
+    ("workspace/inlayHint/refresh") => {
+        $crate::InlayHintRefreshRequest
+    };
+    ("textDocument/diagnostic") => {
+        $crate::DocumentDiagnosticRequest
+    };
+    ("workspace/diagnostic") => {
+        $crate::WorkspaceDiagnosticRequest
+    };
+    ("workspace/diagnostic/refresh") => {
+        $crate::DiagnosticRefreshRequest
+    };
+    ("textDocument/inlineCompletion") => {
+        $crate::InlineCompletionRequest
+    };
+    ("workspace/textDocumentContent") => {
+        $crate::TextDocumentContentRequest
+    };
+    ("workspace/textDocumentContent/refresh") => {
+        $crate::TextDocumentContentRefreshRequest
+    };
+    ("client/registerCapability") => {
+        $crate::RegistrationRequest
+    };
+    ("client/unregisterCapability") => {
+        $crate::UnregistrationRequest
+    };
+    ("initialize") => {
+        $crate::InitializeRequest
+    };
+    ("shutdown") => {
+        $crate::ShutdownRequest
+    };
+    ("window/showMessageRequest") => {
+        $crate::ShowMessageRequest
+    };
+    ("textDocument/willSaveWaitUntil") => {
+        $crate::WillSaveTextDocumentWaitUntilRequest
+    };
+    ("textDocument/completion") => {
+        $crate::CompletionRequest
+    };
+    ("completionItem/resolve") => {
+        $crate::CompletionResolveRequest
+    };
+    ("textDocument/hover") => {
+        $crate::HoverRequest
+    };
+    ("textDocument/signatureHelp") => {
+        $crate::SignatureHelpRequest
+    };
+    ("textDocument/definition") => {
+        $crate::DefinitionRequest
+    };
+    ("textDocument/references") => {
+        $crate::ReferencesRequest
+    };
+    ("textDocument/documentHighlight") => {
+        $crate::DocumentHighlightRequest
+    };
+    ("textDocument/documentSymbol") => {
+        $crate::DocumentSymbolRequest
+    };
+    ("textDocument/codeAction") => {
+        $crate::CodeActionRequest
+    };
+    ("codeAction/resolve") => {
+        $crate::CodeActionResolveRequest
+    };
+    ("workspace/symbol") => {
+        $crate::WorkspaceSymbolRequest
+    };
+    ("workspaceSymbol/resolve") => {
+        $crate::WorkspaceSymbolResolveRequest
+    };
+    ("textDocument/codeLens") => {
+        $crate::CodeLensRequest
+    };
+    ("codeLens/resolve") => {
+        $crate::CodeLensResolveRequest
+    };
+    ("workspace/codeLens/refresh") => {
+        $crate::CodeLensRefreshRequest
+    };
+    ("textDocument/documentLink") => {
+        $crate::DocumentLinkRequest
+    };
+    ("documentLink/resolve") => {
+        $crate::DocumentLinkResolveRequest
+    };
+    ("textDocument/formatting") => {
+        $crate::DocumentFormattingRequest
+    };
+    ("textDocument/rangeFormatting") => {
+        $crate::DocumentRangeFormattingRequest
+    };
+    ("textDocument/rangesFormatting") => {
+        $crate::DocumentRangesFormattingRequest
+    };
+    ("textDocument/onTypeFormatting") => {
+        $crate::DocumentOnTypeFormattingRequest
+    };
+    ("textDocument/rename") => {
+        $crate::RenameRequest
+    };
+    ("textDocument/prepareRename") => {
+        $crate::PrepareRenameRequest
+    };
+    ("workspace/executeCommand") => {
+        $crate::ExecuteCommandRequest
+    };
+    ("workspace/applyEdit") => {
+        $crate::ApplyWorkspaceEditRequest
+    };
+}
+
+/// Get the [`Notification`] type for a notification method.
+///
+/// Example:
+///
+/// ```
+/// use gen_lsp_types::{Notification, lsp_notification};
+/// let params: <lsp_notification!("textDocument/didChange") as Notification>::Params;
+/// ```
+#[macro_export]
+macro_rules! lsp_notification {
+    ("workspace/didChangeWorkspaceFolders") => {
+        $crate::DidChangeWorkspaceFoldersNotification
+    };
+    ("window/workDoneProgress/cancel") => {
+        $crate::WorkDoneProgressCancelNotification
+    };
+    ("workspace/didCreateFiles") => {
+        $crate::DidCreateFilesNotification
+    };
+    ("workspace/didRenameFiles") => {
+        $crate::DidRenameFilesNotification
+    };
+    ("workspace/didDeleteFiles") => {
+        $crate::DidDeleteFilesNotification
+    };
+    ("notebookDocument/didOpen") => {
+        $crate::DidOpenNotebookDocumentNotification
+    };
+    ("notebookDocument/didChange") => {
+        $crate::DidChangeNotebookDocumentNotification
+    };
+    ("notebookDocument/didSave") => {
+        $crate::DidSaveNotebookDocumentNotification
+    };
+    ("notebookDocument/didClose") => {
+        $crate::DidCloseNotebookDocumentNotification
+    };
+    ("initialized") => {
+        $crate::InitializedNotification
+    };
+    ("exit") => {
+        $crate::ExitNotification
+    };
+    ("workspace/didChangeConfiguration") => {
+        $crate::DidChangeConfigurationNotification
+    };
+    ("window/showMessage") => {
+        $crate::ShowMessageNotification
+    };
+    ("window/logMessage") => {
+        $crate::LogMessageNotification
+    };
+    ("telemetry/event") => {
+        $crate::TelemetryEventNotification
+    };
+    ("textDocument/didOpen") => {
+        $crate::DidOpenTextDocumentNotification
+    };
+    ("textDocument/didChange") => {
+        $crate::DidChangeTextDocumentNotification
+    };
+    ("textDocument/didClose") => {
+        $crate::DidCloseTextDocumentNotification
+    };
+    ("textDocument/didSave") => {
+        $crate::DidSaveTextDocumentNotification
+    };
+    ("textDocument/willSave") => {
+        $crate::WillSaveTextDocumentNotification
+    };
+    ("workspace/didChangeWatchedFiles") => {
+        $crate::DidChangeWatchedFilesNotification
+    };
+    ("textDocument/publishDiagnostics") => {
+        $crate::PublishDiagnosticsNotification
+    };
+    ("$/setTrace") => {
+        $crate::SetTraceNotification
+    };
+    ("$/logTrace") => {
+        $crate::LogTraceNotification
+    };
+    ("$/cancelRequest") => {
+        $crate::CancelNotification
+    };
+    ("$/progress") => {
+        $crate::ProgressNotification
+    };
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -722,6 +722,29 @@ mod test {
         assert_eq!(serde_json::to_string(&stpr).unwrap(), stpr_ser);
         assert_eq!(stpr, serde_json::from_str(stpr_ser).unwrap());
     }
+
+    #[test]
+    fn request_macro() {
+        let req = json_rpc::RequestObject::from_request::<lsp_request!("workspace/workspaceFolders")>(
+            json_rpc::Id::Number(123),
+            (),
+        );
+
+        assert_eq!(
+            r#"{"jsonrpc":"2.0","id":123,"method":"workspace/workspaceFolders"}"#,
+            serde_json::to_string(&req).unwrap()
+        );
+    }
+
+    #[test]
+    fn notification_macro() {
+        let req = json_rpc::RequestObject::from_notification::<lsp_notification!("exit")>(());
+
+        assert_eq!(
+            r#"{"jsonrpc":"2.0","method":"exit"}"#,
+            serde_json::to_string(&req).unwrap()
+        );
+    }
 }
 
 /// Tests for the "url" feature.

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -13,8 +13,8 @@ use regex::{Captures, Regex};
 
 use crate::{
     renderers::{
-        render_enum_ors, render_enumeration, render_notification, render_request, render_structure,
-        render_type_alias,
+        render_enum_ors, render_enumeration, render_notification, render_notification_macro,
+        render_request, render_request_macro, render_structure, render_type_alias,
     },
     schema::{
         BaseType, BaseTypes, Enumeration, EnumerationEntry, EnumerationEntryValue, EnumerationType,
@@ -739,6 +739,9 @@ fn main() {
         .flat_map(|ta| render_type_alias(ta, &mut enum_or_types))
         .collect::<Vec<_>>();
 
+    let request_macro = render_request_macro(&model.requests);
+    let notification_macro = render_notification_macro(&model.notifications);
+
     let requests = model
         .requests
         .into_iter()
@@ -766,7 +769,9 @@ fn main() {
         .chain(type_aliases)
         .chain(enum_ors)
         .chain(requests)
-        .chain(notifications);
+        .chain(notifications)
+        .chain(iter::once(request_macro))
+        .chain(iter::once(notification_macro));
 
     let formatted_items: Vec<String> = all_items
         .map(|request| {

--- a/xtask/src/renderers.rs
+++ b/xtask/src/renderers.rs
@@ -901,6 +901,68 @@ pub fn render_structure(
     })
 }
 
+pub fn render_request_macro(requests: &[Request]) -> TokenStream {
+    let reqs = requests.iter().map(|req| {
+        let method = &req.method;
+        let type_ = format_ident!(
+            "{}",
+            req.type_name
+                .as_ref()
+                .expect("Request should have type name")
+        );
+        quote! {
+            (#method) => {
+                $crate::#type_
+            };
+        }
+    });
+    quote! {
+        /// Get the [`Request`] type for a request method.
+        ///
+        /// Example:
+        ///
+        /// ```
+        /// use gen_lsp_types::{Request, lsp_request};
+        /// let params: <lsp_request!("textDocument/formatting") as Request>::Params;
+        /// ```
+        #[macro_export]
+        macro_rules! lsp_request {
+            #(#reqs)*
+        }
+    }
+}
+
+pub fn render_notification_macro(requests: &[Notification]) -> TokenStream {
+    let notis = requests.iter().map(|noti| {
+        let method = &noti.method;
+        let type_ = format_ident!(
+            "{}",
+            noti.type_name
+                .as_ref()
+                .expect("Notification should have type name")
+        );
+        quote! {
+            (#method) => {
+                $crate::#type_
+            };
+        }
+    });
+    quote! {
+        /// Get the [`Notification`] type for a notification method.
+        ///
+        /// Example:
+        ///
+        /// ```
+        /// use gen_lsp_types::{Notification, lsp_notification};
+        /// let params: <lsp_notification!("textDocument/didChange") as Notification>::Params;
+        /// ```
+        #[macro_export]
+        macro_rules! lsp_notification {
+            #(#notis)*
+        }
+    }
+}
+
 /// Render an LSP type.
 ///
 /// Parameters:


### PR DESCRIPTION
These are helper macros to get the associated Request/Notification types for a given method string. These macros exist in the original `lsp-types` crate and should help with compatibility.