### PR TITLE
feat!: bump metamodel

### DIFF
--- a/.github/workflows/check-metamodel.yml
+++ b/.github/workflows/check-metamodel.yml
@@ -44,6 +44,7 @@ jobs:
           else
             echo "::error::The local LSP metamodel is out of sync with the official Microsoft spec."
             echo "::notice::Please update $LOCAL_METAMODEL to match the latest version."
+            echo "curl -o xtask/metaModel.json https://raw.githubusercontent.com/microsoft/language-server-protocol/gh-pages/_specifications/lsp/3.18/metaModel/metaModel.json"
 
             diff -u local_normalized.json upstream_normalized.json || true
             exit 1
@@ -67,6 +68,7 @@ jobs:
           else
             echo "::error::The local LSP metamodel is out of sync with the official Microsoft spec."
             echo "::notice::Please update $LOCAL_METAMODEL_SCHEMA to match the latest version."
+            echo "curl -o xtask/metaModel.schema.json https://raw.githubusercontent.com/microsoft/language-server-protocol/gh-pages/_specifications/lsp/3.18/metaModel/metaModel.schema.json"
 
             diff -u local_normalized.schema.json upstream_normalized.schema.json || true
             exit 1

--- a/src/generated.rs
+++ b/src/generated.rs
@@ -6608,8 +6608,11 @@ pub struct Diagnostic {
     /// appears in the user interface.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub source: Option<String>,
-    /// The diagnostic's message. It usually appears in the user interface
-    pub message: String,
+    /// The diagnostic's message. It usually appears in the user interface.
+    ///
+    /// @since 3.18.0 - support for MarkupContent. This is guarded by the client
+    /// capability `textDocument.diagnostic.markupMessageSupport`.
+    pub message: Message,
     /// Additional metadata about the diagnostic.
     ///
     /// @since 3.15.0
@@ -6634,7 +6637,7 @@ impl Diagnostic {
         code: Option<Code>,
         code_description: Option<CodeDescription>,
         source: Option<String>,
-        message: String,
+        message: Message,
         tags: Option<Vec<DiagnosticTag>>,
         related_information: Option<Vec<DiagnosticRelatedInformation>>,
         data: Option<LspAny>,
@@ -10477,6 +10480,12 @@ pub struct DiagnosticClientCapabilities {
     /// Whether the clients supports related documents for document diagnostic pulls.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub related_document_support: Option<bool>,
+    /// Whether the client supports `MarkupContent` in diagnostic messages.
+    ///
+    /// @since 3.18.0
+    /// @proposed
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub markup_message_support: Option<bool>,
     #[serde(flatten)]
     pub diagnostics_capabilities: DiagnosticsCapabilities,
 }
@@ -10485,11 +10494,13 @@ impl DiagnosticClientCapabilities {
     pub const fn new(
         dynamic_registration: Option<bool>,
         related_document_support: Option<bool>,
+        markup_message_support: Option<bool>,
         diagnostics_capabilities: DiagnosticsCapabilities,
     ) -> Self {
         Self {
             dynamic_registration,
             related_document_support,
+            markup_message_support,
             diagnostics_capabilities,
         }
     }
@@ -15444,6 +15455,43 @@ impl From<MarkedStringWithLanguage> for MarkedString {
 
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone, Eq, Hash)]
 #[serde(untagged)]
+pub enum Message {
+    String(String),
+    MarkupContent(MarkupContent),
+}
+impl From<String> for Message {
+    fn from(v: String) -> Self {
+        Self::String(v)
+    }
+}
+impl From<&str> for Message {
+    fn from(v: &str) -> Self {
+        Self::String(v.into())
+    }
+}
+impl From<char> for Message {
+    fn from(v: char) -> Self {
+        Self::String(v.into())
+    }
+}
+impl From<Box<str>> for Message {
+    fn from(v: Box<str>) -> Self {
+        Self::String(v.into())
+    }
+}
+impl From<Cow<'_, str>> for Message {
+    fn from(v: Cow<'_, str>) -> Self {
+        Self::String(v.into())
+    }
+}
+impl From<MarkupContent> for Message {
+    fn from(v: MarkupContent) -> Self {
+        Self::MarkupContent(v)
+    }
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Debug, Clone, Eq, Hash)]
+#[serde(untagged)]
 pub enum MonikerProvider {
     Bool(bool),
     MonikerOptions(MonikerOptions),
@@ -17584,4 +17632,10 @@ macro_rules! lsp_notification {
     ("$/progress") => {
         $crate::ProgressNotification
     };
+}
+
+impl Default for Message {
+    fn default() -> Self {
+        Message::String(String::default())
+    }
 }

--- a/xtask/metaModel.json
+++ b/xtask/metaModel.json
@@ -9159,10 +9159,20 @@
 				{
 					"name": "message",
 					"type": {
-						"kind": "base",
-						"name": "string"
+						"kind": "or",
+						"items": [
+							{
+								"kind": "base",
+								"name": "string"
+							},
+							{
+								"kind": "reference",
+								"name": "MarkupContent"
+							}
+						]
 					},
-					"documentation": "The diagnostic's message. It usually appears in the user interface"
+					"documentation": "The diagnostic's message. It usually appears in the user interface.\n\n@since 3.18.0 - support for MarkupContent. This is guarded by the client\ncapability `textDocument.diagnostic.markupMessageSupport`.",
+					"since": "3.18.0 - support for MarkupContent. This is guarded by the client\ncapability `textDocument.diagnostic.markupMessageSupport`."
 				},
 				{
 					"name": "tags",
@@ -13384,6 +13394,17 @@
 					},
 					"optional": true,
 					"documentation": "Whether the clients supports related documents for document diagnostic pulls."
+				},
+				{
+					"name": "markupMessageSupport",
+					"type": {
+						"kind": "base",
+						"name": "boolean"
+					},
+					"optional": true,
+					"documentation": "Whether the client supports `MarkupContent` in diagnostic messages.\n\n@since 3.18.0\n@proposed",
+					"since": "3.18.0",
+					"proposed": true
 				}
 			],
 			"extends": [

--- a/xtask/metaModel.schema.json
+++ b/xtask/metaModel.schema.json
@@ -1,9 +1,9 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft-07/schema#",
   "definitions": {
     "AndType": {
       "additionalProperties": false,
-      "description": "Represents an `and`type (e.g. TextDocumentParams & WorkDoneProgressParams`).",
+      "description": "Represents an `and` type (e.g. TextDocumentParams & WorkDoneProgressParams`).",
       "properties": {
         "items": {
           "items": {

--- a/xtask/src/derives.rs
+++ b/xtask/src/derives.rs
@@ -65,6 +65,12 @@ pub fn get_struct_derives(
         derives.push("Ord");
     }
 
+    if structure.name == "Diagnostic" {
+        // We add a custom default impl for the `Diagnostic` message since it is too important not
+        // to have it. In the future, this could maybe be done more generally.
+        derives.push("Default");
+    }
+
     derives
 }
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -682,6 +682,17 @@ fn main() {
         }
     };
 
+    // This allows `Diagnostic` to be `Default`.
+    let postdefs = {
+        quote! {
+            impl Default for Message {
+                fn default() -> Self {
+                    Message::String(String::default())
+                }
+            }
+        }
+    };
+
     let mut enum_or_types = BTreeMap::new();
 
     let structures = model
@@ -799,7 +810,8 @@ fn main() {
         .chain(requests)
         .chain(notifications)
         .chain(iter::once(request_macro))
-        .chain(iter::once(notification_macro));
+        .chain(iter::once(notification_macro))
+        .chain(iter::once(postdefs));
 
     let formatted_items: Vec<String> = all_items
         .map(|request| {


### PR DESCRIPTION
This commit introduces custom, hardcoded `Default` impls for types that
are too important not to have them (i.e., `Diagnostic`).
