### PR TITLE
feat: trait to map partial results to requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,17 @@ Note the `kind` property is not present. However, when serializing, it will
 always be present with a value of `"delete"`. Deserializing only succeeds when
 the field is present and has a `"delete"` value.
 
+### Stronger typing
+
+This library's `Request` and `Notification` traits define not only the
+associated `Params` and `Result` objects, but also their message directions
+(i.e. `ClientToServer`, `ServerToClient`, `Both`). It also defines the method
+string as an `enum`, rather than a `&'static str`.
+
+Additionally, the library defines a `RequestWithPartialResults` trait for
+requests which support streaming partial results. The trait exposes a
+`PartialResult` type for this use case.
+
 ## Notable changes from `lsp-types`
 
 [`lsp-types` controversially

--- a/src/generated/common.rs
+++ b/src/generated/common.rs
@@ -19,6 +19,9 @@ pub trait Request {
     const METHOD: LspRequestMethod<'static>;
     const MESSAGE_DIRECTION: MessageDirection;
 }
+pub trait RequestWithPartialResults: Request {
+    type PartialResult: DeserializeOwned + Serialize + Send + Sync + 'static;
+}
 #[cfg(all(not(feature = "url"), not(feature = "fluent-uri")))]
 /// URIs are transferred as strings. The URI's format is defined in https://tools.ietf.org/html/rfc3986.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]

--- a/src/generated/enum_ors.rs
+++ b/src/generated/enum_ors.rs
@@ -171,6 +171,23 @@ impl From<Cow<'_, str>> for Code {
 
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone, Eq)]
 #[serde(untagged)]
+pub enum CodeActionPartialResponse {
+    Command(Command),
+    CodeAction(CodeAction),
+}
+impl From<Command> for CodeActionPartialResponse {
+    fn from(v: Command) -> Self {
+        Self::Command(v)
+    }
+}
+impl From<CodeAction> for CodeActionPartialResponse {
+    fn from(v: CodeAction) -> Self {
+        Self::CodeAction(v)
+    }
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Debug, Clone, Eq)]
+#[serde(untagged)]
 pub enum CodeActionProvider {
     Bool(bool),
     CodeActionOptions(CodeActionOptions),
@@ -303,6 +320,23 @@ impl From<Vec<Location>> for Declaration {
 
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone, Eq, Hash)]
 #[serde(untagged)]
+pub enum DeclarationPartialResponse {
+    LocationList(Vec<Location>),
+    DeclarationLinkList(Vec<DeclarationLink>),
+}
+impl From<Vec<Location>> for DeclarationPartialResponse {
+    fn from(v: Vec<Location>) -> Self {
+        Self::LocationList(v)
+    }
+}
+impl From<Vec<DeclarationLink>> for DeclarationPartialResponse {
+    fn from(v: Vec<DeclarationLink>) -> Self {
+        Self::DeclarationLinkList(v)
+    }
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Debug, Clone, Eq, Hash)]
+#[serde(untagged)]
 pub enum DeclarationProvider {
     Bool(bool),
     DeclarationOptions(DeclarationOptions),
@@ -361,6 +395,23 @@ impl From<Location> for Definition {
 impl From<Vec<Location>> for Definition {
     fn from(v: Vec<Location>) -> Self {
         Self::LocationList(v)
+    }
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Debug, Clone, Eq, Hash)]
+#[serde(untagged)]
+pub enum DefinitionPartialResponse {
+    LocationList(Vec<Location>),
+    DefinitionLinkList(Vec<DefinitionLink>),
+}
+impl From<Vec<Location>> for DefinitionPartialResponse {
+    fn from(v: Vec<Location>) -> Self {
+        Self::LocationList(v)
+    }
+}
+impl From<Vec<DefinitionLink>> for DefinitionPartialResponse {
+    fn from(v: Vec<DefinitionLink>) -> Self {
+        Self::DefinitionLinkList(v)
     }
 }
 
@@ -537,6 +588,23 @@ impl From<bool> for DocumentRangeFormattingProvider {
 impl From<DocumentRangeFormattingOptions> for DocumentRangeFormattingProvider {
     fn from(v: DocumentRangeFormattingOptions) -> Self {
         Self::DocumentRangeFormattingOptions(v)
+    }
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Debug, Clone, Eq, Hash)]
+#[serde(untagged)]
+pub enum DocumentSymbolPartialResponse {
+    SymbolInformationList(Vec<SymbolInformation>),
+    DocumentSymbolList(Vec<DocumentSymbol>),
+}
+impl From<Vec<SymbolInformation>> for DocumentSymbolPartialResponse {
+    fn from(v: Vec<SymbolInformation>) -> Self {
+        Self::SymbolInformationList(v)
+    }
+}
+impl From<Vec<DocumentSymbol>> for DocumentSymbolPartialResponse {
+    fn from(v: Vec<DocumentSymbol>) -> Self {
+        Self::DocumentSymbolList(v)
     }
 }
 
@@ -762,6 +830,23 @@ impl From<Box<str>> for Id {
 impl From<Cow<'_, str>> for Id {
     fn from(v: Cow<'_, str>) -> Self {
         Self::String(v.into())
+    }
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Debug, Clone, Eq, Hash)]
+#[serde(untagged)]
+pub enum ImplementationPartialResponse {
+    LocationList(Vec<Location>),
+    DefinitionLinkList(Vec<DefinitionLink>),
+}
+impl From<Vec<Location>> for ImplementationPartialResponse {
+    fn from(v: Vec<Location>) -> Self {
+        Self::LocationList(v)
+    }
+}
+impl From<Vec<DefinitionLink>> for ImplementationPartialResponse {
+    fn from(v: Vec<DefinitionLink>) -> Self {
+        Self::DefinitionLinkList(v)
     }
 }
 
@@ -1484,6 +1569,23 @@ impl From<SelectionRangeRegistrationOptions> for SelectionRangeProvider {
 
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone, Eq, Hash)]
 #[serde(untagged)]
+pub enum SemanticTokensDeltaPartialResponse {
+    SemanticTokensPartialResult(SemanticTokensPartialResult),
+    SemanticTokensDeltaPartialResult(SemanticTokensDeltaPartialResult),
+}
+impl From<SemanticTokensPartialResult> for SemanticTokensDeltaPartialResponse {
+    fn from(v: SemanticTokensPartialResult) -> Self {
+        Self::SemanticTokensPartialResult(v)
+    }
+}
+impl From<SemanticTokensDeltaPartialResult> for SemanticTokensDeltaPartialResponse {
+    fn from(v: SemanticTokensDeltaPartialResult) -> Self {
+        Self::SemanticTokensDeltaPartialResult(v)
+    }
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Debug, Clone, Eq, Hash)]
+#[serde(untagged)]
 pub enum SemanticTokensDeltaResponse {
     SemanticTokens(SemanticTokens),
     SemanticTokensDelta(SemanticTokensDelta),
@@ -1664,6 +1766,23 @@ impl From<MarkupContent> for Tooltip {
 
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone, Eq, Hash)]
 #[serde(untagged)]
+pub enum TypeDefinitionPartialResponse {
+    LocationList(Vec<Location>),
+    DefinitionLinkList(Vec<DefinitionLink>),
+}
+impl From<Vec<Location>> for TypeDefinitionPartialResponse {
+    fn from(v: Vec<Location>) -> Self {
+        Self::LocationList(v)
+    }
+}
+impl From<Vec<DefinitionLink>> for TypeDefinitionPartialResponse {
+    fn from(v: Vec<DefinitionLink>) -> Self {
+        Self::DefinitionLinkList(v)
+    }
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Debug, Clone, Eq, Hash)]
+#[serde(untagged)]
 pub enum TypeDefinitionProvider {
     Bool(bool),
     TypeDefinitionOptions(TypeDefinitionOptions),
@@ -1779,6 +1898,23 @@ impl From<Location> for WorkspaceSymbolLocation {
 impl From<LocationUriOnly> for WorkspaceSymbolLocation {
     fn from(v: LocationUriOnly) -> Self {
         Self::LocationUriOnly(v)
+    }
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Debug, Clone, Eq)]
+#[serde(untagged)]
+pub enum WorkspaceSymbolPartialResponse {
+    SymbolInformationList(Vec<SymbolInformation>),
+    WorkspaceSymbolList(Vec<WorkspaceSymbol>),
+}
+impl From<Vec<SymbolInformation>> for WorkspaceSymbolPartialResponse {
+    fn from(v: Vec<SymbolInformation>) -> Self {
+        Self::SymbolInformationList(v)
+    }
+}
+impl From<Vec<WorkspaceSymbol>> for WorkspaceSymbolPartialResponse {
+    fn from(v: Vec<WorkspaceSymbol>) -> Self {
+        Self::WorkspaceSymbolList(v)
     }
 }
 

--- a/src/generated/requests.rs
+++ b/src/generated/requests.rs
@@ -12,6 +12,9 @@ impl Request for ImplementationRequest {
     type Params = ImplementationParams;
     type Result = Option<ImplementationResponse>;
 }
+impl RequestWithPartialResults for ImplementationRequest {
+    type PartialResult = ImplementationPartialResponse;
+}
 
 /// A request to resolve the type definition locations of a symbol at a given text
 /// document position. The request's parameter is of type [`TextDocumentPositionParams`]
@@ -23,6 +26,9 @@ impl Request for TypeDefinitionRequest {
     const MESSAGE_DIRECTION: MessageDirection = MessageDirection::ClientToServer;
     type Params = TypeDefinitionParams;
     type Result = Option<TypeDefinitionResponse>;
+}
+impl RequestWithPartialResults for TypeDefinitionRequest {
+    type PartialResult = TypeDefinitionPartialResponse;
 }
 
 /// The `workspace/workspaceFolders` is sent from the server to the client to fetch the open workspace folders.
@@ -63,6 +69,9 @@ impl Request for DocumentColorRequest {
     type Params = DocumentColorParams;
     type Result = Option<Vec<ColorInformation>>;
 }
+impl RequestWithPartialResults for DocumentColorRequest {
+    type PartialResult = Vec<ColorInformation>;
+}
 
 /// A request to list all presentation for a color. The request's
 /// parameter is of type [`ColorPresentationParams`] the
@@ -76,6 +85,9 @@ impl Request for ColorPresentationRequest {
     type Params = ColorPresentationParams;
     type Result = Option<Vec<ColorPresentation>>;
 }
+impl RequestWithPartialResults for ColorPresentationRequest {
+    type PartialResult = Vec<ColorPresentation>;
+}
 
 /// A request to provide folding ranges in a document. The request's
 /// parameter is of type [`FoldingRangeParams`], the
@@ -88,6 +100,9 @@ impl Request for FoldingRangeRequest {
     const MESSAGE_DIRECTION: MessageDirection = MessageDirection::ClientToServer;
     type Params = FoldingRangeParams;
     type Result = Option<Vec<FoldingRange>>;
+}
+impl RequestWithPartialResults for FoldingRangeRequest {
+    type PartialResult = Vec<FoldingRange>;
 }
 
 /// @since 3.18.0
@@ -113,6 +128,9 @@ impl Request for DeclarationRequest {
     type Params = DeclarationParams;
     type Result = Option<DeclarationResponse>;
 }
+impl RequestWithPartialResults for DeclarationRequest {
+    type PartialResult = DeclarationPartialResponse;
+}
 
 /// A request to provide selection ranges in a document. The request's
 /// parameter is of type [`SelectionRangeParams`], the
@@ -125,6 +143,9 @@ impl Request for SelectionRangeRequest {
     const MESSAGE_DIRECTION: MessageDirection = MessageDirection::ClientToServer;
     type Params = SelectionRangeParams;
     type Result = Option<Vec<SelectionRange>>;
+}
+impl RequestWithPartialResults for SelectionRangeRequest {
+    type PartialResult = Vec<SelectionRange>;
 }
 
 /// The `window/workDoneProgress/create` request is sent from the server to the client to initiate progress
@@ -162,6 +183,9 @@ impl Request for CallHierarchyIncomingCallsRequest {
     type Params = CallHierarchyIncomingCallsParams;
     type Result = Option<Vec<CallHierarchyIncomingCall>>;
 }
+impl RequestWithPartialResults for CallHierarchyIncomingCallsRequest {
+    type PartialResult = Vec<CallHierarchyIncomingCall>;
+}
 
 /// A request to resolve the outgoing calls for a given `CallHierarchyItem`.
 ///
@@ -174,6 +198,9 @@ impl Request for CallHierarchyOutgoingCallsRequest {
     type Params = CallHierarchyOutgoingCallsParams;
     type Result = Option<Vec<CallHierarchyOutgoingCall>>;
 }
+impl RequestWithPartialResults for CallHierarchyOutgoingCallsRequest {
+    type PartialResult = Vec<CallHierarchyOutgoingCall>;
+}
 
 /// @since 3.16.0
 #[derive(Debug)]
@@ -183,6 +210,9 @@ impl Request for SemanticTokensRequest {
     const MESSAGE_DIRECTION: MessageDirection = MessageDirection::ClientToServer;
     type Params = SemanticTokensParams;
     type Result = Option<SemanticTokens>;
+}
+impl RequestWithPartialResults for SemanticTokensRequest {
+    type PartialResult = SemanticTokensPartialResult;
 }
 
 /// @since 3.16.0
@@ -194,6 +224,9 @@ impl Request for SemanticTokensDeltaRequest {
     type Params = SemanticTokensDeltaParams;
     type Result = Option<SemanticTokensDeltaResponse>;
 }
+impl RequestWithPartialResults for SemanticTokensDeltaRequest {
+    type PartialResult = SemanticTokensDeltaPartialResponse;
+}
 
 /// @since 3.16.0
 #[derive(Debug)]
@@ -203,6 +236,9 @@ impl Request for SemanticTokensRangeRequest {
     const MESSAGE_DIRECTION: MessageDirection = MessageDirection::ClientToServer;
     type Params = SemanticTokensRangeParams;
     type Result = Option<SemanticTokens>;
+}
+impl RequestWithPartialResults for SemanticTokensRangeRequest {
+    type PartialResult = SemanticTokensPartialResult;
 }
 
 /// @since 3.16.0
@@ -296,6 +332,9 @@ impl Request for MonikerRequest {
     type Params = MonikerParams;
     type Result = Option<Vec<Moniker>>;
 }
+impl RequestWithPartialResults for MonikerRequest {
+    type PartialResult = Vec<Moniker>;
+}
 
 /// A request to result a `TypeHierarchyItem` in a document at a given position.
 /// Can be used as an input to a subtypes or supertypes type hierarchy.
@@ -321,6 +360,9 @@ impl Request for TypeHierarchySupertypesRequest {
     type Params = TypeHierarchySupertypesParams;
     type Result = Option<Vec<TypeHierarchyItem>>;
 }
+impl RequestWithPartialResults for TypeHierarchySupertypesRequest {
+    type PartialResult = Vec<TypeHierarchyItem>;
+}
 
 /// A request to resolve the subtypes for a given `TypeHierarchyItem`.
 ///
@@ -332,6 +374,9 @@ impl Request for TypeHierarchySubtypesRequest {
     const MESSAGE_DIRECTION: MessageDirection = MessageDirection::ClientToServer;
     type Params = TypeHierarchySubtypesParams;
     type Result = Option<Vec<TypeHierarchyItem>>;
+}
+impl RequestWithPartialResults for TypeHierarchySubtypesRequest {
+    type PartialResult = Vec<TypeHierarchyItem>;
 }
 
 /// A request to provide inline values in a document. The request's parameter is of
@@ -346,6 +391,9 @@ impl Request for InlineValueRequest {
     const MESSAGE_DIRECTION: MessageDirection = MessageDirection::ClientToServer;
     type Params = InlineValueParams;
     type Result = Option<Vec<InlineValue>>;
+}
+impl RequestWithPartialResults for InlineValueRequest {
+    type PartialResult = Vec<InlineValue>;
 }
 
 /// @since 3.17.0
@@ -370,6 +418,9 @@ impl Request for InlayHintRequest {
     const MESSAGE_DIRECTION: MessageDirection = MessageDirection::ClientToServer;
     type Params = InlayHintParams;
     type Result = Option<Vec<InlayHint>>;
+}
+impl RequestWithPartialResults for InlayHintRequest {
+    type PartialResult = Vec<InlayHint>;
 }
 
 /// A request to resolve additional properties for an inlay hint.
@@ -407,6 +458,9 @@ impl Request for DocumentDiagnosticRequest {
     type Params = DocumentDiagnosticParams;
     type Result = DocumentDiagnosticReport;
 }
+impl RequestWithPartialResults for DocumentDiagnosticRequest {
+    type PartialResult = DocumentDiagnosticReportPartialResult;
+}
 
 /// The workspace diagnostic request definition.
 ///
@@ -418,6 +472,9 @@ impl Request for WorkspaceDiagnosticRequest {
     const MESSAGE_DIRECTION: MessageDirection = MessageDirection::ClientToServer;
     type Params = WorkspaceDiagnosticParams;
     type Result = WorkspaceDiagnosticReport;
+}
+impl RequestWithPartialResults for WorkspaceDiagnosticRequest {
+    type PartialResult = WorkspaceDiagnosticReportPartialResult;
 }
 
 /// The diagnostic refresh request definition.
@@ -445,6 +502,9 @@ impl Request for InlineCompletionRequest {
     const MESSAGE_DIRECTION: MessageDirection = MessageDirection::ClientToServer;
     type Params = InlineCompletionParams;
     type Result = Option<InlineCompletionResponse>;
+}
+impl RequestWithPartialResults for InlineCompletionRequest {
+    type PartialResult = Vec<InlineCompletionItem>;
 }
 
 /// The `workspace/textDocumentContent` request is sent from the client to the
@@ -567,6 +627,9 @@ impl Request for CompletionRequest {
     type Params = CompletionParams;
     type Result = Option<CompletionResponse>;
 }
+impl RequestWithPartialResults for CompletionRequest {
+    type PartialResult = Vec<CompletionItem>;
+}
 
 /// Request to resolve additional information for a given completion item.The request's
 /// parameter is of type [`CompletionItem`] the response
@@ -613,6 +676,9 @@ impl Request for DefinitionRequest {
     type Params = DefinitionParams;
     type Result = Option<DefinitionResponse>;
 }
+impl RequestWithPartialResults for DefinitionRequest {
+    type PartialResult = DefinitionPartialResponse;
+}
 
 /// A request to resolve project-wide references for the symbol denoted
 /// by the given text document position. The request's parameter is of
@@ -625,6 +691,9 @@ impl Request for ReferencesRequest {
     const MESSAGE_DIRECTION: MessageDirection = MessageDirection::ClientToServer;
     type Params = ReferenceParams;
     type Result = Option<Vec<Location>>;
+}
+impl RequestWithPartialResults for ReferencesRequest {
+    type PartialResult = Vec<Location>;
 }
 
 /// Request to resolve a [`DocumentHighlight`] for a given
@@ -639,6 +708,9 @@ impl Request for DocumentHighlightRequest {
     type Params = DocumentHighlightParams;
     type Result = Option<Vec<DocumentHighlight>>;
 }
+impl RequestWithPartialResults for DocumentHighlightRequest {
+    type PartialResult = Vec<DocumentHighlight>;
+}
 
 /// A request to list all symbols found in a given text document. The request's
 /// parameter is of type [`TextDocumentIdentifier`] the
@@ -652,6 +724,9 @@ impl Request for DocumentSymbolRequest {
     type Params = DocumentSymbolParams;
     type Result = Option<DocumentSymbolResponse>;
 }
+impl RequestWithPartialResults for DocumentSymbolRequest {
+    type PartialResult = DocumentSymbolPartialResponse;
+}
 
 /// A request to provide commands for the given text document and range.
 #[derive(Debug)]
@@ -661,6 +736,9 @@ impl Request for CodeActionRequest {
     const MESSAGE_DIRECTION: MessageDirection = MessageDirection::ClientToServer;
     type Params = CodeActionParams;
     type Result = Option<Vec<CodeActionResponse>>;
+}
+impl RequestWithPartialResults for CodeActionRequest {
+    type PartialResult = Vec<CodeActionPartialResponse>;
 }
 
 /// Request to resolve additional information for a given code action.The request's
@@ -692,6 +770,9 @@ impl Request for WorkspaceSymbolRequest {
     type Params = WorkspaceSymbolParams;
     type Result = Option<WorkspaceSymbolResponse>;
 }
+impl RequestWithPartialResults for WorkspaceSymbolRequest {
+    type PartialResult = WorkspaceSymbolPartialResponse;
+}
 
 /// A request to resolve the range inside the workspace
 /// symbol's location.
@@ -714,6 +795,9 @@ impl Request for CodeLensRequest {
     const MESSAGE_DIRECTION: MessageDirection = MessageDirection::ClientToServer;
     type Params = CodeLensParams;
     type Result = Option<Vec<CodeLens>>;
+}
+impl RequestWithPartialResults for CodeLensRequest {
+    type PartialResult = Vec<CodeLens>;
 }
 
 /// A request to resolve a command for a given code lens.
@@ -746,6 +830,9 @@ impl Request for DocumentLinkRequest {
     const MESSAGE_DIRECTION: MessageDirection = MessageDirection::ClientToServer;
     type Params = DocumentLinkParams;
     type Result = Option<Vec<DocumentLink>>;
+}
+impl RequestWithPartialResults for DocumentLinkRequest {
+    type PartialResult = Vec<DocumentLink>;
 }
 
 /// Request to resolve additional information for a given document link. The request's

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -687,6 +687,48 @@ mod test {
     }
 
     #[test]
+    fn request_with_partial_results() {
+        fn foo<R: RequestWithPartialResults>(
+            _params: R::Params,
+            _partial_result: R::PartialResult,
+        ) {
+            // Do nothing!
+        }
+
+        foo::<DocumentSymbolRequest>(
+            DocumentSymbolParams {
+                text_document: TextDocumentIdentifier { uri: "".into() },
+                work_done_progress_params: WorkDoneProgressParams {
+                    work_done_token: None,
+                },
+                partial_result_params: PartialResultParams {
+                    partial_result_token: None,
+                },
+            },
+            DocumentSymbolPartialResponse::SymbolInformationList(vec![SymbolInformation {
+                deprecated: None,
+                location: Location {
+                    uri: "".into(),
+                    range: Range::default(),
+                },
+                base_symbol_information: BaseSymbolInformation {
+                    name: String::new(),
+                    kind: SymbolKind::File,
+                    tags: None,
+                    container_name: None,
+                },
+            }]),
+        );
+
+        let partial_result = DocumentSymbolPartialResponse::DocumentSymbolList(Vec::new());
+        let _ = match partial_result {
+            DocumentSymbolPartialResponse::SymbolInformationList(_) => 1,
+            DocumentSymbolPartialResponse::DocumentSymbolList(_) => 2,
+            // No `null` branch
+        };
+    }
+
+    #[test]
     #[allow(clippy::similar_names)]
     fn semantic_tokens() {
         let ste = SemanticTokensEdit {

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -485,6 +485,10 @@ fn main() {
             const MESSAGE_DIRECTION: MessageDirection;
         }
 
+        pub trait RequestWithPartialResults: Request {
+            type PartialResult: DeserializeOwned + Serialize + Send + Sync + 'static;
+        }
+
         #[cfg(all(not(feature = "url"), not(feature = "fluent-uri")))]
         /// URIs are transferred as strings. The URI's format is defined in https://tools.ietf.org/html/rfc3986.
         #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]

--- a/xtask/src/renderers.rs
+++ b/xtask/src/renderers.rs
@@ -233,21 +233,45 @@ pub fn render_request(
         quote! { () }
     };
     let mut result = request.result;
-    let is_nullable = is_nullable(&result);
-    if is_nullable {
+    let is_result_nullable = is_nullable(&result);
+    if is_result_nullable {
         collapse_null(&mut result);
     }
     let resp_name = name
         .strip_suffix("Request")
-        .expect("Request name should end in request")
+        .expect("Request name should end in \"Request\"")
         .to_owned()
         + "Response";
     let mut result = render_type(result, &resp_name, None, enum_or_types);
-    if is_nullable {
+    if is_result_nullable {
         result = quote! { Option<#result> };
     }
+    let deprecated = request
+        .deprecated
+        .map(|note| quote! {#[deprecated(note = #note)]});
+    let partial_impl = request.partial_result.map(|mut type_| {
+        let is_nullable = is_nullable(&type_);
+        if is_nullable {
+            collapse_null(&mut type_);
+        }
+        let partial_resp_name = name
+            .strip_suffix("Request")
+            .expect("Request name should end in \"Request\"")
+            .to_owned()
+            + "PartialResponse";
+        let mut partial_result = render_type(type_, &partial_resp_name, None, enum_or_types);
+        if is_nullable {
+            partial_result = quote! { Option<#partial_result> };
+        }
+        quote! {
+            impl RequestWithPartialResults for #name_ident {
+                type PartialResult = #partial_result;
+            }
+        }
+    });
     quote! {
         #documentation
+        #deprecated
         #[derive(Debug)]
         pub enum #name_ident {}
 
@@ -258,6 +282,8 @@ pub fn render_request(
             type Params = #params;
             type Result = #result;
         }
+
+        #partial_impl
     }
 }
 


### PR DESCRIPTION
The new `RequestWithPartialResults` trait (supertrait of `Request`) will now be implemented on `Request`s which also support streaming partial result progress.