### PR TITLE
fix!: generalize `SemanticTokensEdit` `data` property

### DIFF
--- a/src/generated/structures.rs
+++ b/src/generated/structures.rs
@@ -4870,21 +4870,12 @@ pub struct SemanticTokensEdit {
     /// The count of elements to remove.
     pub delete_count: u32,
     /// The elements to insert.
-    #[serde(
-        default,
-        skip_serializing_if = "Option::is_none",
-        deserialize_with = "SemanticToken::deserialize_optional_tokens",
-        serialize_with = "SemanticToken::serialize_optional_tokens"
-    )]
-    pub data: Option<Vec<SemanticToken>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data: Option<Vec<u32>>,
 }
 impl SemanticTokensEdit {
     #[must_use]
-    pub const fn new(
-        start: u32,
-        delete_count: u32,
-        data: Option<Vec<SemanticToken>>,
-    ) -> Self {
+    pub const fn new(start: u32, delete_count: u32, data: Option<Vec<u32>>) -> Self {
         Self { start, delete_count, data }
     }
 }
@@ -11084,36 +11075,6 @@ impl SemanticToken {
             seq.serialize_element(&token.token_modifiers_bitset)?;
         }
         seq.end()
-    }
-    fn deserialize_optional_tokens<'de, D>(
-        deserializer: D,
-    ) -> Result<Option<Vec<SemanticToken>>, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        #[derive(Deserialize)]
-        #[serde(transparent)]
-        struct Wrapper {
-            #[serde(deserialize_with = "SemanticToken::deserialize_tokens")]
-            tokens: Vec<SemanticToken>,
-        }
-        Ok(Option::<Wrapper>::deserialize(deserializer)?.map(|wrapper| wrapper.tokens))
-    }
-    fn serialize_optional_tokens<S>(
-        data: &Option<Vec<SemanticToken>>,
-        serializer: S,
-    ) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        #[derive(Serialize)]
-        #[serde(transparent)]
-        struct Wrapper {
-            #[serde(serialize_with = "SemanticToken::serialize_tokens")]
-            tokens: Vec<SemanticToken>,
-        }
-        let opt = data.as_ref().map(|t| Wrapper { tokens: t.clone() });
-        opt.serialize(serializer)
     }
 }
 #[derive(Debug, Eq, Hash, PartialEq, Clone, Deserialize, Serialize)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -772,24 +772,9 @@ mod test {
         let ste = SemanticTokensEdit {
             start: 0,
             delete_count: 1,
-            data: Some(vec![
-                SemanticToken {
-                    delta_line: 2,
-                    delta_start: 5,
-                    length: 3,
-                    token_type: 0,
-                    token_modifiers_bitset: 3,
-                },
-                SemanticToken {
-                    delta_line: 0,
-                    delta_start: 5,
-                    length: 4,
-                    token_type: 1,
-                    token_modifiers_bitset: 0,
-                },
-            ]),
+            data: Some(vec![2, 5, 3, 4, 1, 0]),
         };
-        let ste_ser = r#"{"start":0,"deleteCount":1,"data":[2,5,3,0,3,0,5,4,1,0]}"#;
+        let ste_ser = r#"{"start":0,"deleteCount":1,"data":[2,5,3,4,1,0]}"#;
         assert_eq!(serde_json::to_string(&ste).unwrap(), ste_ser);
         assert_eq!(ste, serde_json::from_str(ste_ser).unwrap());
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -699,41 +699,6 @@ fn main() {
                     }
                     seq.end()
                 }
-
-                fn deserialize_optional_tokens<'de, D>(
-                    deserializer: D,
-                ) -> Result<Option<Vec<SemanticToken>>, D::Error>
-                where
-                    D: serde::Deserializer<'de>,
-                {
-                    #[derive(Deserialize)]
-                    #[serde(transparent)]
-                    struct Wrapper {
-                        #[serde(deserialize_with = "SemanticToken::deserialize_tokens")]
-                        tokens: Vec<SemanticToken>,
-                    }
-
-                    Ok(Option::<Wrapper>::deserialize(deserializer)?.map(|wrapper| wrapper.tokens))
-                }
-
-                fn serialize_optional_tokens<S>(
-                    data: &Option<Vec<SemanticToken>>,
-                    serializer: S,
-                ) -> Result<S::Ok, S::Error>
-                where
-                    S: serde::Serializer,
-                {
-                    #[derive(Serialize)]
-                    #[serde(transparent)]
-                    struct Wrapper {
-                        #[serde(serialize_with = "SemanticToken::serialize_tokens")]
-                        tokens: Vec<SemanticToken>,
-                    }
-
-                    let opt = data.as_ref().map(|t| Wrapper { tokens: t.clone() });
-
-                    opt.serialize(serializer)
-                }
             }
 
             #[derive(Debug, Eq, Hash, PartialEq, Clone, Deserialize, Serialize)]

--- a/xtask/src/renderers.rs
+++ b/xtask/src/renderers.rs
@@ -780,36 +780,6 @@ fn get_special_property(
 ) -> Option<TokenStream> {
     let property_name = property.name.as_str();
     match (structure_name, property_name) {
-        ("SemanticTokensEdit", "data") => {
-            assert_eq!(property.optional, Some(true));
-            assert_eq!(
-                property.type_,
-                Type::ArrayType(
-                    ArrayType {
-                        kind: "array".into(),
-                        element: Type::BaseType(BaseType {
-                            kind: "base".into(),
-                            name: BaseTypes::Uinteger
-                        })
-                    }
-                    .into()
-                )
-            );
-            let documentation = render_documentation(property.documentation.clone());
-            let deprecated = property.deprecated.as_deref().map(render_deprecated);
-            props_simplified.push((quote! { data }, quote! { Option<Vec<SemanticToken>> }));
-            Some(quote! {
-                #documentation
-                #deprecated
-                #[serde(
-                    default,
-                    skip_serializing_if = "Option::is_none",
-                    deserialize_with = "SemanticToken::deserialize_optional_tokens",
-                    serialize_with = "SemanticToken::serialize_optional_tokens"
-                )]
-                pub data: Option<Vec<SemanticToken>>,
-            })
-        }
         ("SemanticTokens" | "SemanticTokensPartialResult", "data") => {
             assert_ne!(property.optional, Some(true));
             assert_eq!(


### PR DESCRIPTION
The library erroneously used the special `SemanticToken` serialization strategy for edit data. However, edit data does not need to be a multiple of 5, and isn't mapped 1-to-1 to an array of semantic tokens. Thus, to support arbitrary edit data, we must generalize the property in this case back to a `Vec<u32>`.