### PR TITLE
feat: `WithUri` trait to generically access `Uri`s

### DIFF
--- a/src/generated/common.rs
+++ b/src/generated/common.rs
@@ -666,6 +666,16 @@ macro_rules! lsp_request {
     };
 }
 
+/// Provides generic access to a struct's (potentially nested) field of type [`crate::Uri`].
+pub trait WithUri {
+    fn uri(&self) -> &Uri;
+}
+impl WithUri for Uri {
+    fn uri(&self) -> &Uri {
+        self
+    }
+}
+
 /// Get the [`Notification`] type for a notification method.
 ///
 /// Example:

--- a/src/generated/structures.rs
+++ b/src/generated/structures.rs
@@ -11107,3 +11107,393 @@ pub enum MessageActionItemProperty {
     Int(i32),
     Object(LspObject),
 }
+
+impl WithUri for CallHierarchyItem {
+    fn uri(&self) -> &Uri {
+        &self.uri
+    }
+}
+
+impl WithUri for CallHierarchyPrepareParams {
+    fn uri(&self) -> &Uri {
+        &self.text_document_position_params.text_document.uri
+    }
+}
+
+impl WithUri for CodeActionParams {
+    fn uri(&self) -> &Uri {
+        &self.text_document.uri
+    }
+}
+
+impl WithUri for CodeLensParams {
+    fn uri(&self) -> &Uri {
+        &self.text_document.uri
+    }
+}
+
+impl WithUri for ColorPresentationParams {
+    fn uri(&self) -> &Uri {
+        &self.text_document.uri
+    }
+}
+
+impl WithUri for CompletionParams {
+    fn uri(&self) -> &Uri {
+        &self.text_document_position_params.text_document.uri
+    }
+}
+
+impl WithUri for CreateFile {
+    fn uri(&self) -> &Uri {
+        &self.uri
+    }
+}
+
+impl WithUri for DeclarationParams {
+    fn uri(&self) -> &Uri {
+        &self.text_document_position_params.text_document.uri
+    }
+}
+
+impl WithUri for DefinitionParams {
+    fn uri(&self) -> &Uri {
+        &self.text_document_position_params.text_document.uri
+    }
+}
+
+impl WithUri for DeleteFile {
+    fn uri(&self) -> &Uri {
+        &self.uri
+    }
+}
+
+impl WithUri for DidChangeTextDocumentParams {
+    fn uri(&self) -> &Uri {
+        &self.text_document.text_document_identifier.uri
+    }
+}
+
+impl WithUri for DidCloseTextDocumentParams {
+    fn uri(&self) -> &Uri {
+        &self.text_document.uri
+    }
+}
+
+impl WithUri for DidOpenTextDocumentParams {
+    fn uri(&self) -> &Uri {
+        &self.text_document.uri
+    }
+}
+
+impl WithUri for DidSaveTextDocumentParams {
+    fn uri(&self) -> &Uri {
+        &self.text_document.uri
+    }
+}
+
+impl WithUri for DocumentColorParams {
+    fn uri(&self) -> &Uri {
+        &self.text_document.uri
+    }
+}
+
+impl WithUri for DocumentDiagnosticParams {
+    fn uri(&self) -> &Uri {
+        &self.text_document.uri
+    }
+}
+
+impl WithUri for DocumentFormattingParams {
+    fn uri(&self) -> &Uri {
+        &self.text_document.uri
+    }
+}
+
+impl WithUri for DocumentHighlightParams {
+    fn uri(&self) -> &Uri {
+        &self.text_document_position_params.text_document.uri
+    }
+}
+
+impl WithUri for DocumentLinkParams {
+    fn uri(&self) -> &Uri {
+        &self.text_document.uri
+    }
+}
+
+impl WithUri for DocumentOnTypeFormattingParams {
+    fn uri(&self) -> &Uri {
+        &self.text_document.uri
+    }
+}
+
+impl WithUri for DocumentRangeFormattingParams {
+    fn uri(&self) -> &Uri {
+        &self.text_document.uri
+    }
+}
+
+impl WithUri for DocumentRangesFormattingParams {
+    fn uri(&self) -> &Uri {
+        &self.text_document.uri
+    }
+}
+
+impl WithUri for DocumentSymbolParams {
+    fn uri(&self) -> &Uri {
+        &self.text_document.uri
+    }
+}
+
+impl WithUri for FileCreate {
+    fn uri(&self) -> &Uri {
+        &self.uri
+    }
+}
+
+impl WithUri for FileDelete {
+    fn uri(&self) -> &Uri {
+        &self.uri
+    }
+}
+
+impl WithUri for FileEvent {
+    fn uri(&self) -> &Uri {
+        &self.uri
+    }
+}
+
+impl WithUri for FoldingRangeParams {
+    fn uri(&self) -> &Uri {
+        &self.text_document.uri
+    }
+}
+
+impl WithUri for HoverParams {
+    fn uri(&self) -> &Uri {
+        &self.text_document_position_params.text_document.uri
+    }
+}
+
+impl WithUri for ImplementationParams {
+    fn uri(&self) -> &Uri {
+        &self.text_document_position_params.text_document.uri
+    }
+}
+
+impl WithUri for InlayHintParams {
+    fn uri(&self) -> &Uri {
+        &self.text_document.uri
+    }
+}
+
+impl WithUri for InlineCompletionParams {
+    fn uri(&self) -> &Uri {
+        &self.text_document_position_params.text_document.uri
+    }
+}
+
+impl WithUri for InlineValueParams {
+    fn uri(&self) -> &Uri {
+        &self.text_document.uri
+    }
+}
+
+impl WithUri for LinkedEditingRangeParams {
+    fn uri(&self) -> &Uri {
+        &self.text_document_position_params.text_document.uri
+    }
+}
+
+impl WithUri for Location {
+    fn uri(&self) -> &Uri {
+        &self.uri
+    }
+}
+
+impl WithUri for LocationUriOnly {
+    fn uri(&self) -> &Uri {
+        &self.uri
+    }
+}
+
+impl WithUri for MonikerParams {
+    fn uri(&self) -> &Uri {
+        &self.text_document_position_params.text_document.uri
+    }
+}
+
+impl WithUri for NotebookDocument {
+    fn uri(&self) -> &Uri {
+        &self.uri
+    }
+}
+
+impl WithUri for NotebookDocumentIdentifier {
+    fn uri(&self) -> &Uri {
+        &self.uri
+    }
+}
+
+impl WithUri for OptionalVersionedTextDocumentIdentifier {
+    fn uri(&self) -> &Uri {
+        &self.text_document_identifier.uri
+    }
+}
+
+impl WithUri for PrepareRenameParams {
+    fn uri(&self) -> &Uri {
+        &self.text_document_position_params.text_document.uri
+    }
+}
+
+impl WithUri for PreviousResultId {
+    fn uri(&self) -> &Uri {
+        &self.uri
+    }
+}
+
+impl WithUri for PublishDiagnosticsParams {
+    fn uri(&self) -> &Uri {
+        &self.uri
+    }
+}
+
+impl WithUri for ReferenceParams {
+    fn uri(&self) -> &Uri {
+        &self.text_document_position_params.text_document.uri
+    }
+}
+
+impl WithUri for RenameParams {
+    fn uri(&self) -> &Uri {
+        &self.text_document_position_params.text_document.uri
+    }
+}
+
+impl WithUri for SelectionRangeParams {
+    fn uri(&self) -> &Uri {
+        &self.text_document.uri
+    }
+}
+
+impl WithUri for SemanticTokensDeltaParams {
+    fn uri(&self) -> &Uri {
+        &self.text_document.uri
+    }
+}
+
+impl WithUri for SemanticTokensParams {
+    fn uri(&self) -> &Uri {
+        &self.text_document.uri
+    }
+}
+
+impl WithUri for SemanticTokensRangeParams {
+    fn uri(&self) -> &Uri {
+        &self.text_document.uri
+    }
+}
+
+impl WithUri for ShowDocumentParams {
+    fn uri(&self) -> &Uri {
+        &self.uri
+    }
+}
+
+impl WithUri for SignatureHelpParams {
+    fn uri(&self) -> &Uri {
+        &self.text_document_position_params.text_document.uri
+    }
+}
+
+impl WithUri for TextDocumentContentParams {
+    fn uri(&self) -> &Uri {
+        &self.uri
+    }
+}
+
+impl WithUri for TextDocumentContentRefreshParams {
+    fn uri(&self) -> &Uri {
+        &self.uri
+    }
+}
+
+impl WithUri for TextDocumentEdit {
+    fn uri(&self) -> &Uri {
+        &self.text_document.text_document_identifier.uri
+    }
+}
+
+impl WithUri for TextDocumentIdentifier {
+    fn uri(&self) -> &Uri {
+        &self.uri
+    }
+}
+
+impl WithUri for TextDocumentItem {
+    fn uri(&self) -> &Uri {
+        &self.uri
+    }
+}
+
+impl WithUri for TextDocumentPositionParams {
+    fn uri(&self) -> &Uri {
+        &self.text_document.uri
+    }
+}
+
+impl WithUri for TypeDefinitionParams {
+    fn uri(&self) -> &Uri {
+        &self.text_document_position_params.text_document.uri
+    }
+}
+
+impl WithUri for TypeHierarchyItem {
+    fn uri(&self) -> &Uri {
+        &self.uri
+    }
+}
+
+impl WithUri for TypeHierarchyPrepareParams {
+    fn uri(&self) -> &Uri {
+        &self.text_document_position_params.text_document.uri
+    }
+}
+
+impl WithUri for VersionedNotebookDocumentIdentifier {
+    fn uri(&self) -> &Uri {
+        &self.uri
+    }
+}
+
+impl WithUri for VersionedTextDocumentIdentifier {
+    fn uri(&self) -> &Uri {
+        &self.text_document_identifier.uri
+    }
+}
+
+impl WithUri for WillSaveTextDocumentParams {
+    fn uri(&self) -> &Uri {
+        &self.text_document.uri
+    }
+}
+
+impl WithUri for WorkspaceFolder {
+    fn uri(&self) -> &Uri {
+        &self.uri
+    }
+}
+
+impl WithUri for WorkspaceFullDocumentDiagnosticReport {
+    fn uri(&self) -> &Uri {
+        &self.uri
+    }
+}
+
+impl WithUri for WorkspaceUnchangedDocumentDiagnosticReport {
+    fn uri(&self) -> &Uri {
+        &self.uri
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -936,6 +936,28 @@ mod test {
         assert_eq!(ser, r#"{"kind":"markdown","value":"foo"}"#);
         assert_eq!(contents, serde_json::from_str(&ser).unwrap());
     }
+
+    #[test]
+    fn with_uri_accesses_uri() {
+        let uri = Uri::from("file://rust/is/a/must.rs");
+        let tdi = TextDocumentIdentifier { uri: uri.clone() };
+        let vtdi = VersionedTextDocumentIdentifier {
+            text_document_identifier: tdi.clone(),
+            version: 1,
+        };
+        let ler_params = LinkedEditingRangeParams {
+            work_done_progress_params: WorkDoneProgressParams::default(),
+            text_document_position_params: TextDocumentPositionParams {
+                text_document: tdi.clone(),
+                position: Position::default(),
+            },
+        };
+
+        assert_eq!(&uri, vtdi.uri());
+        assert_eq!(&uri, tdi.uri());
+        assert_eq!(&uri, uri.uri());
+        assert_eq!(&uri, ler_params.uri());
+    }
 }
 
 /// Tests for the "url" feature.

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,5 +1,6 @@
 mod derives;
 mod renderers;
+mod with_uri;
 
 use std::{
     assert_matches,
@@ -14,7 +15,7 @@ use crate::{
     renderers::{
         render_enum_ors, render_enumeration, render_notification, render_notification_macro,
         render_request, render_request_macro, render_request_methods, render_structure,
-        render_type_alias,
+        render_type_alias, render_with_uri_impls, render_with_uri_trait,
     },
     schema::{
         ArrayType, BaseType, BaseTypes, Enumeration, MapKeyType, OrType, Property, ReferenceType,
@@ -573,11 +574,13 @@ fn main() {
         use serde::{de::DeserializeOwned, Deserialize, Serialize};
         use std::{borrow::Cow, fmt};
     };
+
     let common = [
         common_imports,
         predefs,
         methods,
         request_macro,
+        render_with_uri_trait(),
         notification_macro,
     ]
     .into_iter();
@@ -735,9 +738,12 @@ fn main() {
             }
         }
     };
+
+    let with_uri_impls = render_with_uri_impls(&structs_map);
     let structures = iter::once(structure_imports)
         .chain(structures)
-        .chain(iter::once(structure_postdefs));
+        .chain(iter::once(structure_postdefs))
+        .chain(with_uri_impls);
 
     let type_alias_imports = quote! {
         #[allow(clippy::wildcard_imports)]

--- a/xtask/src/renderers.rs
+++ b/xtask/src/renderers.rs
@@ -106,6 +106,41 @@ fn render_deprecated(note: &str) -> TokenStream {
     quote! { #[deprecated(note = #note)] }
 }
 
+pub fn render_with_uri_trait() -> TokenStream {
+    quote! {
+        /// Provides generic access to a struct's (potentially nested) field of type [`crate::Uri`].
+        pub trait WithUri {
+            fn uri(&self) -> &Uri;
+        }
+
+        impl WithUri for Uri {
+            fn uri(&self) -> &Uri {
+                self
+            }
+        }
+    }
+}
+
+pub fn render_with_uri_impls(structs_map: &HashMap<String, Structure>) -> Vec<TokenStream> {
+    crate::with_uri::get_structs_with_uri(structs_map)
+        .into_iter()
+        .map(|(name, keys)| {
+            let name = format_ident!("{name}");
+            let keys = keys.into_iter().map(|key| {
+                let ident = format_ident!("{key}");
+                quote! { .#ident }
+            });
+            quote! {
+                impl WithUri for #name {
+                    fn uri(&self) -> &Uri {
+                        &self #(#keys)*
+                    }
+                }
+            }
+        })
+        .collect()
+}
+
 pub fn render_enum_ors(
     structs_map: &HashMap<String, Structure>,
     enums_map: &HashMap<String, Enumeration>,

--- a/xtask/src/with_uri.rs
+++ b/xtask/src/with_uri.rs
@@ -1,0 +1,68 @@
+use std::collections::{BTreeMap, HashMap};
+
+use crate::{
+    camel_to_snake,
+    schema::{BaseType, BaseTypes, ReferenceType, Structure, Type},
+};
+
+const URI_PROPERTY: &str = "uri";
+const TEXT_DOCUMENT_PROPERTY: &str = "textDocument";
+
+const fn is_uri_type(type_: &Type) -> bool {
+    matches!(
+        type_,
+        Type::BaseType(BaseType {
+            kind: _,
+            name: BaseTypes::Uri | BaseTypes::DocumentUri,
+        })
+    )
+}
+
+pub fn get_structs_with_uri(
+    structs_map: &HashMap<String, Structure>,
+) -> BTreeMap<String, Vec<String>> {
+    structs_map
+        .iter()
+        .filter_map(|(k, v)| get_uri_fields(structs_map, v).map(|x| (k.clone(), x)))
+        .collect()
+}
+
+fn get_uri_fields(
+    structs_map: &HashMap<String, Structure>,
+    struct_: &Structure,
+) -> Option<Vec<String>> {
+    if let Some(prop) = struct_
+        .properties
+        .iter()
+        .find(|p| p.name == URI_PROPERTY && p.optional != Some(true) && is_uri_type(&p.type_))
+    {
+        return Some(vec![camel_to_snake(&prop.name)]);
+    }
+
+    if let Some(prop) = struct_
+        .properties
+        .iter()
+        .find(|p| p.name == TEXT_DOCUMENT_PROPERTY)
+        && let Type::ReferenceType(ReferenceType { name, .. }) = &prop.type_
+        && let Some(s) = structs_map.get(name)
+        && let Some(mut fields) = get_uri_fields(structs_map, s)
+    {
+        let mut all_fields = Vec::with_capacity(fields.len() + 1);
+        all_fields.push(camel_to_snake(&prop.name));
+        all_fields.append(&mut fields);
+        return Some(all_fields);
+    }
+
+    struct_.mixins.iter().chain(&struct_.extends).find_map(|p| {
+        let Type::ReferenceType(ReferenceType { name, .. }) = p else {
+            unreachable!("mixins are always references")
+        };
+        let s = structs_map.get(name)?;
+        get_uri_fields(structs_map, s).map(|mut fields| {
+            let mut all_fields = Vec::with_capacity(fields.len() + 1);
+            all_fields.push(camel_to_snake(name));
+            all_fields.append(&mut fields);
+            all_fields
+        })
+    })
+}


### PR DESCRIPTION
Adds a `WithUri` trait, allowing generic access to `Uri` on 64 types with a `uri` field with type `Uri`. Some types like `FileCreate`/`FileDelete` have `String` as the type for their `uri` fields

Types implementing `WithUri` are 
- 43 params types
  - 13 types referenced by said params types
- 4 types inside of response types. For example, `Location` carries a `Uri`
- `Uri` itself
- 3 in both params and results (`CallHierarchyItem`)

Some types cannot safely `impl WithUri, for example `ReferencesRequest` is responded with a `Option<Vec<Location>>`

I built this trait since I wanted to validate a `Uri` was open before sending requests for arbitrary request parameters

Closes #69 