### PR TITLE
chore: use explicit includes in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/ribru17/gen-lsp-types"
 keywords = ["lsp", "codegen"]
 readme = "README.md"
 categories = ["development-tools"]
-exclude = ["/.github/"]
+include = ["src/**/*", "LICENSE", "README.md"]
 
 [lib]
 path = "src/lib.rs"


### PR DESCRIPTION
Changes Cargo.toml to use includes instead of excludes, removing `.gitignore` and `.cargo/config.toml` from the final package

This is only 42 bytes difference, so this is mainly stylistic 😃 

```diff
$ cargo package --list
- .cargo/config.toml
.cargo_vcs_info.json
- .gitignore
Cargo.lock
Cargo.toml
Cargo.toml.orig
LICENSE
README.md
src/generated/common.rs
src/generated/enum_ors.rs
src/generated/enumerations.rs
src/generated/notifications.rs
src/generated/requests.rs
src/generated/structures.rs
src/generated/type_aliases.rs
src/generated.rs
src/json_rpc.rs
src/lib.rs
```